### PR TITLE
fix: add types declaration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "version": "1.0.1",
   "main": "dist/index.js",
+  "types": "dist/types.d.ts",
   "repository": "git@github.com:krzkaczor/ts-essentials.git",
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "license": "MIT",


### PR DESCRIPTION
Currently types are not linked by `package.json` and will only be available if the environment recursively pulls all `*.d.ts` in `node_modules`, which is not always the case.