### PR TITLE
Remove custom NonNullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ yarn add --dev ts-essentials
 
 - [Basic](#basic)
   - Primitive
-  - NonNullable
 - [Dictionaries](#dictionaries)
   - Dictionary
   - DictionaryValues
@@ -40,7 +39,6 @@ yarn add --dev ts-essentials
 ### Basic:
 
 - `Primitive` type matching all primitive values.
-- `NonNullable` remove `null` and `undefined` from union type.
 
 ### Dictionaries
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -35,9 +35,6 @@ export type DeepReadonly<T> = T extends Primitive
 type DeepReadonlyObject<T> = { readonly [P in keyof T]: DeepReadonly<T[P]> };
 interface DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
 
-/** Make sure that T is not null or undefined */
-export type NonNullable<T> = T & {};
-
 /** Omit given key in object type */
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 


### PR DESCRIPTION
⚠️ breaking change

I might miss something, but can't find a reason behind this custom implementation. If there is any I would appreciate an explanation why it's needed.