### PR TITLE
Add ReadonlyArray<T> check in DeepReadonly

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,7 +17,7 @@ export type DeepPartial<T> = {
 /** Like Required but recursive */
 export type DeepRequired<T> = T extends Primitive
   ? NonNullable<T>
-  : T extends any[]
+  : T extends (any[] | ReadonlyArray<any>)
   ? DeepRequiredArray<NonNullable<T[number]>>
   : T extends {}
   ? { [K in keyof T]-?: DeepRequired<NonNullable<T[K]>> }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,7 +17,7 @@ export type DeepPartial<T> = {
 /** Like Required but recursive */
 export type DeepRequired<T> = T extends Primitive
   ? NonNullable<T>
-  : T extends (any[] | ReadonlyArray<any>)
+  : T extends any[]
   ? DeepRequiredArray<NonNullable<T[number]>>
   : T extends {}
   ? { [K in keyof T]-?: DeepRequired<NonNullable<T[K]>> }
@@ -27,7 +27,7 @@ interface DeepRequiredArray<T> extends Array<DeepRequired<T>> {}
 /** Like Readonly but recursive */
 export type DeepReadonly<T> = T extends Primitive
   ? T
-  : T extends any[]
+  : T extends (any[] | ReadonlyArray<any>)
   ? DeepReadonlyArray<T[number]>
   : T extends Function
   ? T

--- a/test/index.ts
+++ b/test/index.ts
@@ -25,17 +25,17 @@ function testDeepReadonly1() {
 }
 
 interface IDeepReadonlyTestHelperType extends DeepReadonly<{
-	field: string[];
+  field: string[];
 }> {}
 
 // Build-time test to ensure the fix for https://github.com/krzkaczor/ts-essentials/issues/17 remains in place.
 function testDeepReadonly2() {
   const a: DeepReadonly<IDeepReadonlyTestHelperType> = {
-	  field: ['lala'],
+    field: ['lala'],
   };
 
   let b: IDeepReadonlyTestHelperType = {
-	  field: ['lala'],
+    field: ['lala'],
   };
 
   b = a;

--- a/test/index.ts
+++ b/test/index.ts
@@ -31,11 +31,11 @@ interface IDeepReadonlyTestHelperType extends DeepReadonly<{
 // Build-time test to ensure the fix for https://github.com/krzkaczor/ts-essentials/issues/17 remains in place.
 function testDeepReadonly2() {
   const a: DeepReadonly<IDeepReadonlyTestHelperType> = {
-    field: ['lala'],
+    field: ["lala"]
   };
 
   let b: IDeepReadonlyTestHelperType = {
-    field: ['lala'],
+    field: ["lala"]
   };
 
   b = a;

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,7 +4,7 @@
 import { IsExactType as IsExact, AssertTrue as Assert } from "conditional-type-checks";
 import { DeepReadonly, DeepRequired, Tuple } from "../lib";
 
-function testDeepReadonly() {
+function testDeepReadonly1() {
   type Input = {
     a: number[][];
     nested: {
@@ -22,6 +22,23 @@ function testDeepReadonly() {
   }>;
 
   type Test = Assert<IsExact<DeepReadonly<Input>, Expected>>;
+}
+
+interface IDeepReadonlyTestHelperType extends DeepReadonly<{
+	field: string[];
+}> {}
+
+// Build-time test to ensure the fix for https://github.com/krzkaczor/ts-essentials/issues/17 remains in place.
+function testDeepReadonly2() {
+  const a: DeepReadonly<IDeepReadonlyTestHelperType> = {
+	  field: ['lala'],
+  };
+
+  let b: IDeepReadonlyTestHelperType = {
+	  field: ['lala'],
+  };
+
+  b = a;
 }
 
 function testNonNullable() {

--- a/test/index.ts
+++ b/test/index.ts
@@ -28,14 +28,15 @@ interface IDeepReadonlyTestHelperType extends DeepReadonly<{
   field: string[];
 }> {}
 
-// Build-time test to ensure the fix for https://github.com/krzkaczor/ts-essentials/issues/17 remains in place.
+// Build-time test to ensure the fix for
+// https://github.com/krzkaczor/ts-essentials/issues/17 remains in place.
 function testDeepReadonly2() {
   const a: DeepReadonly<IDeepReadonlyTestHelperType> = {
-    field: ["lala"]
+    field: ["lala"],
   };
 
   let b: IDeepReadonlyTestHelperType = {
-    field: ["lala"]
+    field: ["lala"],
   };
 
   b = a;

--- a/test/index.ts
+++ b/test/index.ts
@@ -24,9 +24,10 @@ function testDeepReadonly1() {
   type Test = Assert<IsExact<DeepReadonly<Input>, Expected>>;
 }
 
-interface IDeepReadonlyTestHelperType extends DeepReadonly<{
-  field: string[];
-}> {}
+interface IDeepReadonlyTestHelperType
+  extends DeepReadonly<{
+    field: string[];
+  }> {}
 
 // Build-time test to ensure the fix for
 // https://github.com/krzkaczor/ts-essentials/issues/17 remains in place.


### PR DESCRIPTION
As per https://github.com/krzkaczor/ts-essentials/issues/17, DeepReadonly wasn't properly recognizing a ReadonlyArray\<T> as matching any[], with the result being that such fields were wrapped in an extra DeepReadonlyObject type, which caused type clashing elsewhere. See the issue for a repro.