### PR TITLE
readme: add description text for `Writable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ type ComplexObjectReadonly = DeepReadonly<ComplexObject>;
 
 ### Writable
 
+Make all attributes of object writable.
+
 ```typescript
 type Foo = {
   readonly a: number,


### PR DESCRIPTION
For some of the types (e.g. `Omit`, `Dictionary`) they are pretty self-explanatory. But, I feel `Writable` is not. So, proposing to add a description for it to readme.