### PR TITLE
fix(package.json): function definition not exported

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "version": "2.0.4",
   "main": "dist/index.js",
-  "types": "dist/types.d.ts",
+  "types": "dist/index.d.ts",
   "repository": "git@github.com:krzkaczor/ts-essentials.git",
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "license": "MIT",


### PR DESCRIPTION
Before this fix, only type definitions are exported. This fixes https://github.com/krzkaczor/ts-essentials/issues/26 .