### PR TITLE
test: add test testDeepWritableReverseIsDeepReadonlyForTotallyWritableType

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -137,3 +137,16 @@ function testDeepWritable2() {
   test[0].foo = "b";
   test[0].bar.x = 2;
 }
+
+// Test whether for totally writable types, apply DeepReadonly then DeepWritable will yield the original type
+function testDeepWritableReverseIsDeepReadonlyForTotallyWritableType() {
+  type TotallyWritableType = {
+    a: number[][];
+    nested: {
+      a: 1;
+    };
+    numberArray: number[];
+  }[];
+
+  type Test = Assert<IsExact<DeepWritable<DeepReadonly<TotallyWritableType>>, TotallyWritableType>>;
+}


### PR DESCRIPTION
Test whether for totally writable types, apply `DeepReadonly` then `DeepWritable` will yield the original type. This is expected to be true for all totally writable types.