### PR TITLE
Fix DeepReadonly<unknown>

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,7 +31,9 @@ export type DeepReadonly<T> = T extends Primitive
   ? DeepReadonlyArray<T[number]>
   : T extends Function
   ? T
-  : DeepReadonlyObject<T>;
+  : T extends {}
+  ? DeepReadonlyObject<T>
+  : unknown;
 type DeepReadonlyObject<T> = { readonly [P in keyof T]: DeepReadonly<T[P]> };
 interface DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,6 +11,12 @@ function testDeepReadonly1() {
       a: 1;
     };
     readonlyAlready: ReadonlyArray<number>;
+    stringProperty: string;
+    numberProperty: number;
+    booleanProperty: boolean;
+    unknownProperty: unknown;
+    nullProperty: null;
+    undefinedProperty: undefined;
   }[];
 
   type Expected = ReadonlyArray<{
@@ -19,6 +25,12 @@ function testDeepReadonly1() {
       readonly a: 1;
     };
     readonly readonlyAlready: ReadonlyArray<number>;
+    readonly stringProperty: string;
+    readonly numberProperty: number;
+    readonly booleanProperty: boolean;
+    readonly unknownProperty: unknown;
+    readonly nullProperty: null;
+    readonly undefinedProperty: undefined;
   }>;
 
   type Test = Assert<IsExact<DeepReadonly<Input>, Expected>>;


### PR DESCRIPTION
This commit makes `unknown` assignable to `DeepReadonly<unknown>`.