### PR TITLE
test: improve testDeepWritableReverseIsDeepReadonlyForTotallyWritableType

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -160,5 +160,6 @@ function testDeepWritableReverseIsDeepReadonlyForTotallyWritableType() {
     numberArray: number[];
   }[];
 
+  type Test_Indeed_Obj_Totally_Writable = Assert<IsExact< TotallyWritableType, DeepWritable<TotallyWritableType> >>;
   type Test = Assert<IsExact<DeepWritable<DeepReadonly<TotallyWritableType>>, TotallyWritableType>>;
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -160,6 +160,8 @@ function testDeepWritableReverseIsDeepReadonlyForTotallyWritableType() {
     numberArray: number[];
   }[];
 
-  type Test_Indeed_Obj_Totally_Writable = Assert<IsExact< TotallyWritableType, DeepWritable<TotallyWritableType>>>;
+  type Test_Indeed_Obj_Totally_Writable = Assert<
+    IsExact<TotallyWritableType, DeepWritable<TotallyWritableType>>
+  >;
   type Test = Assert<IsExact<DeepWritable<DeepReadonly<TotallyWritableType>>, TotallyWritableType>>;
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -160,8 +160,6 @@ function testDeepWritableReverseIsDeepReadonlyForTotallyWritableType() {
     numberArray: number[];
   }[];
 
-  type Test_Indeed_Obj_Totally_Writable = Assert<
-    IsExact<TotallyWritableType, DeepWritable<TotallyWritableType>>
-  >;
+  type Test_Indeed_Obj_Totally_Writable = Assert<IsExact<TotallyWritableType, DeepWritable<TotallyWritableType>>>;
   type Test = Assert<IsExact<DeepWritable<DeepReadonly<TotallyWritableType>>, TotallyWritableType>>;
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -160,6 +160,6 @@ function testDeepWritableReverseIsDeepReadonlyForTotallyWritableType() {
     numberArray: number[];
   }[];
 
-  type Test_Indeed_Obj_Totally_Writable = Assert<IsExact< TotallyWritableType, DeepWritable<TotallyWritableType> >>;
+  type Test_Indeed_Obj_Totally_Writable = Assert<IsExact< TotallyWritableType, DeepWritable<TotallyWritableType>>>;
   type Test = Assert<IsExact<DeepWritable<DeepReadonly<TotallyWritableType>>, TotallyWritableType>>;
 }


### PR DESCRIPTION
An improvement related to PR https://github.com/krzkaczor/ts-essentials/pull/33 . Add checks whether a `TotallyWritableType` is unchanged by `DeepWritable`.