### PR TITLE
Refactor ReaadonlyKeys & WritableKeys, include helper explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ type Result = ReadonlyKeys<T>
 
 ### WritableKeys
 
-Gets keys of an object which are writable
+Gets keys of an object which are writable.
 
 ```typescript
 type T = {


### PR DESCRIPTION
This is a follow-up to #59 -- I refactored the "dark magic" helper to be more readable, and added a few lines of magic explanation with a reference link, in case this needs to be updated later.