### PR TITLE
Implement DeepOmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,32 +25,32 @@ yarn add --dev ts-essentials
 
 ## What's inside?
 
-- [Install](#install)
-- [What's inside?](#whats-inside)
-  - [Basic:](#basic)
-  - [Dictionaries](#dictionaries)
-  - [Deep Partial & Deep Required & Deep Readonly & Deep NonNullable](#deep-partial--deep-required--deep-readonly--deep-nonnullable)
-  - [Writable](#writable)
-  - [Omit](#omit)
-  - [StrictOmit](#strictomit)
-    - [Comparison between `Omit` and `StrictOmit`](#comparison-between-omit-and-strictomit)
-  - [DeepOmit](#deepomit)
-  - [OmitProperties](#omitproperties)
-  - [NonNever](#nonnever)
-  - [Merge](#merge)
-  - [MarkRequired](#markrequired)
-  - [ReadonlyKeys](#readonlykeys)
-  - [WritableKeys](#writablekeys)
-  - [UnionToIntersection](#uniontointersection)
-  - [Opaque types](#opaque-types)
-  - [Tuple constraint](#tuple-constraint)
-  - [Literal types](#literal-types)
-  - [Exhaustive switch cases](#exhaustive-switch-cases)
-  - [ValueOf type](#valueof-type)
-  - [AsyncOrSync type](#asyncorsync-type)
-- [Contributors](#contributors)
+- [Install](#Install)
+- [What's inside?](#Whats-inside)
+  - [Basic](#Basic)
+  - [Dictionaries](#Dictionaries)
+  - [Deep Partial & Deep Required & Deep Readonly & Deep NonNullable](#Deep-Partial--Deep-Required--Deep-Readonly--Deep-NonNullable)
+  - [Writable](#Writable)
+  - [Omit](#Omit)
+  - [StrictOmit](#StrictOmit)
+    - [Comparison between `Omit` and `StrictOmit`](#Comparison-between-Omit-and-StrictOmit)
+  - [DeepOmit](#DeepOmit)
+  - [OmitProperties](#OmitProperties)
+  - [NonNever](#NonNever)
+  - [Merge](#Merge)
+  - [MarkRequired](#MarkRequired)
+  - [ReadonlyKeys](#ReadonlyKeys)
+  - [WritableKeys](#WritableKeys)
+  - [UnionToIntersection](#UnionToIntersection)
+  - [Opaque types](#Opaque-types)
+  - [Tuple constraint](#Tuple-constraint)
+  - [Literal types](#Literal-types)
+  - [Exhaustive switch cases](#Exhaustive-switch-cases)
+  - [ValueOf type](#ValueOf-type)
+  - [AsyncOrSync type](#AsyncOrSync-type)
+- [Contributors](#Contributors)
 
-### Basic:
+### Basic
 
 - `Primitive` type matching all primitive values.
 
@@ -228,13 +228,13 @@ interface Teacher {
 
 Now suppose you want to omit `gender` property of `Teacher`, and `score` property of `students`. You can achieve this with a simple type filter.
 
-In the filter, the properties to be omitted completely should be defined as `true`. For the properties you want to partially omit, you should recursively define the sub-properties to be omitted.
+In the filter, the properties to be omitted completely should be defined as `never`. For the properties you want to partially omit, you should recursively define the sub-properties to be omitted.
 
 ```typescript
 type TeacherSimple = DeepOmit<Teacher, {
-  gender: true,
+  gender: never,
   students: {
-    score: true,
+    score: never,
   }
 }>
 
@@ -245,7 +245,8 @@ type TeacherSimple = DeepOmit<Teacher, {
 // }
 ```
 
-NOTE: 
+NOTE
+
 - `DeepOmit` works fine with `Array`s and `Set`s. When applied to a `Map`, the filter is only applied to its value.
 - If there exists any property in the filter which is not in the original type, an error will occur.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ yarn add --dev ts-essentials
   - [Deep Partial & Deep Required & Deep Readonly & Deep NonNullable](#Deep-Partial--Deep-Required--Deep-Readonly--Deep-NonNullable)
   - [Writable](#Writable)
   - [Omit](#Omit)
+  - [DeepOmit](#DeepOmit)
   - [OmitProperties](#OmitProperties)
   - [NonNever](#NonNever)
   - [Merge](#Merge)
@@ -162,30 +163,44 @@ test[0].bar.x = 2;
 
 ### Omit
 
+Removed in `v3`.
+
 NOTE: Builtin `Omit` became part of TypeScript 3.5
 
+### DeepOmit
+
+Recursively omit deep properties according to key names.
+
+Here is the `Teacher` interface.
+
 ```typescript
-type ComplexObject = {
-  simple: number;
-  nested: {
-    a: string;
-    array: [{ bar: number }];
-  };
-};
-
-type SimplifiedComplexObject = Omit<ComplexObject, "nested">;
-
-// Result:
-// {
-//  simple: number
-// }
-
-// if you want to Omit multiple properties just use union type:
-type SimplifiedComplexObject = Omit<ComplexObject, "nested" | "simple">;
-
-// Result:
-// { } (empty type)
+interface Teacher {
+  name: string,
+  gender: string,
+  students: {name: string, score: number}[]
+}
 ```
+
+Now suppose you want to omit `gender` property of `Teacher`, and `score` property of `students`. You can simple define a filter like this, and then use `DeepOmit`.
+
+```typescript
+interface Filter {
+  gender: "gender",
+  students: {
+    score: "score",
+  }
+}
+
+type TeacherSimple = DeepOmit<Teacher, Filter>
+
+// The result will be:
+{
+  name: string,
+  students: {name: string}[]
+}
+```
+
+NOTE: `DeepOmit` works fine with `Array`s and `Set`s. When applied to a  `Map`, if its key and value shares common properties, both will be omitted.
 
 ### OmitProperties
 

--- a/README.md
+++ b/README.md
@@ -181,23 +181,25 @@ interface Teacher {
 }
 ```
 
-Now suppose you want to omit `gender` property of `Teacher`, and `score` property of `students`. You can simple define a filter like this, and then use `DeepOmit`.
+Now suppose you want to omit `gender` property of `Teacher`, and `score` property of `students`. You can simple define a filter type and then use `DeepOmit`.
+
+In the filter type, the properties to be omitted completely should be defined as `true`. For the properties you want to partially omit, you should recursively define the sub-properties to be omitted.
 
 ```typescript
 interface Filter {
-  gender: "gender",
+  gender: true,
   students: {
-    score: "score",
+    score: true,
   }
 }
 
 type TeacherSimple = DeepOmit<Teacher, Filter>
 
 // The result will be:
-{
-  name: string,
-  students: {name: string}[]
-}
+// {
+//  name: string,
+//  students: {name: string}[]
+// }
 ```
 
 NOTE: `DeepOmit` works fine with `Array`s and `Set`s. When applied to a  `Map`, if its key and value shares common properties, both will be omitted.

--- a/example/types.ts
+++ b/example/types.ts
@@ -3,7 +3,6 @@ import {
   DictionaryValues,
   DeepPartial,
   DeepReadonly,
-  Omit,
   Opaque,
   DeepRequired,
   AsyncOrSync,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -125,7 +125,9 @@ export type DeepOmit<T extends DeepOmitModify<P>, P> = T extends Primitive | Fun
         },
         never
       >;
-type DeepOmitSuper<P> = { [K in keyof P]: P[K] extends true ? any : DeepOmitModify<P[K]> };
+type DeepOmitSuper<P> = {
+  [K in keyof P]: P[K] extends never ? any : P[K] extends object ? DeepOmitModify<P[K]> : never;
+};
 type DeepOmitModify<P> =
   | DeepOmitSuper<P>
   | Array<DeepOmitSuper<P>>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -106,9 +106,9 @@ export type DeepOmit<T, P extends {}> = T extends Primitive | Function | Date
   : T extends Array<infer U>
   ? DeepOmitArray<U, P>
   : T extends {}
-  ? { [K in Exclude<keyof T, keyof P>]: T[K] } & OmitProperties<DeepOmitAffected<T, P>, never>
+  ? { [K in Exclude<keyof T, keyof P>]: T[K] } &
+      OmitProperties<{ [K in Extract<keyof T, keyof P>]: P[K] extends true ? never : DeepOmit<T[K], P[K]> }, never>
   : T;
-type DeepOmitAffected<T, P> = { [K in Extract<keyof T, keyof P>]: P[K] extends K ? never : DeepOmit<T[K], P[K]> };
 interface DeepOmitArray<ItemType, P> extends Array<DeepOmit<ItemType, P>> {}
 interface DeepOmitSet<ItemType, P> extends Set<DeepOmit<ItemType, P>> {}
 interface DeepOmitMap<KeyType, ValueType, P> extends Map<DeepOmit<KeyType, P>, DeepOmit<ValueType, P>> {}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -128,11 +128,10 @@ export type DeepOmit<T extends DeepOmitModify<P>, P> = T extends Primitive | Fun
 type DeepOmitSuper<P> = {
   [K in keyof P]: P[K] extends never ? any : P[K] extends object ? DeepOmitModify<P[K]> : never;
 };
-type DeepOmitModify<P> =
-  | DeepOmitSuper<P>
-  | Array<DeepOmitSuper<P>>
-  | Set<DeepOmitSuper<P>>
-  | Map<any, DeepOmitSuper<P>>;
+type DeepOmitModify<P> = DeepOmitSuper<P> | DeepOmitModifyArray<P> | DeepOmitModifySet<P> | DeepOmitModifyMap<P>;
+interface DeepOmitModifyArray<ItemType> extends Array<DeepOmitModify<ItemType>> {}
+interface DeepOmitModifySet<ItemType> extends Set<DeepOmitModify<ItemType>> {}
+interface DeepOmitModifyMap<ValueType> extends Map<any, DeepOmitModify<ValueType>> {}
 interface DeepOmitArray<ItemType extends DeepOmitModify<P>, P> extends Array<DeepOmit<ItemType, P>> {}
 interface DeepOmitSet<ItemType extends DeepOmitModify<P>, P> extends Set<DeepOmit<ItemType, P>> {}
 interface DeepOmitMap<KeyType, ValueType extends DeepOmitModify<P>, P> extends Map<KeyType, DeepOmit<ValueType, P>> {}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -125,18 +125,7 @@ export type DeepOmit<T extends DeepOmitModify<P>, P> = T extends Primitive | Fun
         },
         never
       >;
-type DeepOmitSuper<P> = P extends Primitive | Function | Date
-  ? P
-  : P extends Map<infer K, infer V>
-  ? DeepOmitSuperMap<K, V>
-  : P extends Set<infer U>
-  ? DeepOmitSuperSet<U>
-  : P extends Array<infer U>
-  ? DeepOmitSuperArray<U>
-  : { [K in keyof P]: P[K] extends true ? any : DeepOmitModify<P[K]> };
-interface DeepOmitSuperArray<ItemType> extends Array<DeepOmitSuper<ItemType>> {}
-interface DeepOmitSuperSet<ItemType> extends Set<DeepOmitSuper<ItemType>> {}
-interface DeepOmitSuperMap<KeyType, ValueType> extends Map<KeyType, DeepOmitSuper<ValueType>> {}
+type DeepOmitSuper<P> = { [K in keyof P]: P[K] extends true ? any : DeepOmitModify<P[K]> };
 type DeepOmitModify<P> =
   | DeepOmitSuper<P>
   | Array<DeepOmitSuper<P>>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -100,41 +100,42 @@ export type StrictOmit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type OmitProperties<T, P> = Pick<T, { [K in keyof T]: T[K] extends P ? never : K }[keyof T]>;
 
 /** Recursively omit deep properties */
-export type DeepOmit<T extends DeepOmitModify<P>, P> = T extends Primitive | Function | Date
+export type DeepOmit<T extends DeepOmitModify<Filter>, Filter> = T extends Primitive | Function | Date
   ? T
-  : T extends Map<infer K, infer V>
-  ? V extends DeepOmitModify<P>
-    ? DeepOmitMap<K, V, P>
+  : T extends Map<infer KeyType, infer ValueType>
+  ? ValueType extends DeepOmitModify<Filter>
+    ? DeepOmitMap<KeyType, ValueType, Filter>
     : T
-  : T extends Set<infer U>
-  ? U extends DeepOmitModify<P>
-    ? DeepOmitSet<U, P>
+  : T extends Set<infer ItemType>
+  ? ItemType extends DeepOmitModify<Filter>
+    ? DeepOmitSet<ItemType, Filter>
     : T
-  : T extends Array<infer U>
-  ? U extends DeepOmitModify<P>
-    ? DeepOmitArray<U, P>
+  : T extends Array<infer ItemType>
+  ? ItemType extends DeepOmitModify<Filter>
+    ? DeepOmitArray<ItemType, Filter>
     : T
-  : { [K in Exclude<keyof T, keyof P>]: T[K] } &
+  : { [K in Exclude<keyof T, keyof Filter>]: T[K] } &
       OmitProperties<
         {
-          [K in Extract<keyof T, keyof P>]: P[K] extends true
+          [K in Extract<keyof T, keyof Filter>]: Filter[K] extends true
             ? never
-            : T[K] extends DeepOmitModify<P[K]>
-            ? DeepOmit<T[K], P[K]>
+            : T[K] extends DeepOmitModify<Filter[K]>
+            ? DeepOmit<T[K], Filter[K]>
             : T[K];
         },
         never
       >;
-type DeepOmitSuper<P> = {
-  [K in keyof P]: P[K] extends never ? any : P[K] extends object ? DeepOmitModify<P[K]> : never;
+type DeepOmitSuper<T> = {
+  [K in keyof T]: T[K] extends never ? any : T[K] extends object ? DeepOmitModify<T[K]> : never;
 };
-type DeepOmitModify<P> = DeepOmitSuper<P> | DeepOmitModifyArray<P> | DeepOmitModifySet<P> | DeepOmitModifyMap<P>;
+type DeepOmitModify<T> = DeepOmitSuper<T> | DeepOmitModifyArray<T> | DeepOmitModifySet<T> | DeepOmitModifyMap<T>;
 interface DeepOmitModifyArray<ItemType> extends Array<DeepOmitModify<ItemType>> {}
 interface DeepOmitModifySet<ItemType> extends Set<DeepOmitModify<ItemType>> {}
 interface DeepOmitModifyMap<ValueType> extends Map<any, DeepOmitModify<ValueType>> {}
-interface DeepOmitArray<ItemType extends DeepOmitModify<P>, P> extends Array<DeepOmit<ItemType, P>> {}
-interface DeepOmitSet<ItemType extends DeepOmitModify<P>, P> extends Set<DeepOmit<ItemType, P>> {}
-interface DeepOmitMap<KeyType, ValueType extends DeepOmitModify<P>, P> extends Map<KeyType, DeepOmit<ValueType, P>> {}
+interface DeepOmitArray<ItemType extends DeepOmitModify<Filter>, Filter> extends Array<DeepOmit<ItemType, Filter>> {}
+interface DeepOmitSet<ItemType extends DeepOmitModify<Filter>, Filter> extends Set<DeepOmit<ItemType, Filter>> {}
+interface DeepOmitMap<KeyType, ValueType extends DeepOmitModify<Filter>, Filter>
+  extends Map<KeyType, DeepOmit<ValueType, Filter>> {}
 
 /** Remove keys with `never` value from object type */
 export type NonNever<T extends {}> = Pick<T, { [K in keyof T]: T[K] extends never ? never : K }[keyof T]>;

--- a/test/index.ts
+++ b/test/index.ts
@@ -177,21 +177,23 @@ function testDeepOmit() {
 
   type Filter = {
     a: {
-      b: true;
+      b: never;
       c: {
-        d: true;
+        d: never;
       };
     };
     array: {
-      a: true;
+      a: never;
     };
     set: {
-      a: true;
+      a: never;
     };
     map: {
-      a: true;
+      a: never;
     };
   };
+
+  type T = DeepOmit<Nested, Filter>;
 
   type Test = Assert<IsExact<DeepOmit<Nested, Filter>, Omitted>>;
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -193,8 +193,6 @@ function testDeepOmit() {
     };
   };
 
-  type T = DeepOmit<Nested, Filter>;
-
   type Test = Assert<IsExact<DeepOmit<Nested, Filter>, Omitted>>;
 }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -160,7 +160,7 @@ function testDeepOmit() {
     };
     array: { a: string; b: boolean }[];
     set: Set<{ a: string; b: boolean }>;
-    map: Map<number, {a: string, b: boolean}>
+    map: Map<number, { a: string; b: boolean }>;
   };
 
   type Omitted = {
@@ -172,26 +172,28 @@ function testDeepOmit() {
     };
     array: { b: boolean }[];
     set: Set<{ b: boolean }>;
-    map: Map<number, {b: boolean}>
+    map: Map<number, { b: boolean }>;
   };
 
   type Filter = {
     a: {
-      b: "b";
+      b: true;
       c: {
-        d: "d";
+        d: true;
       };
     };
     array: {
-      a: "a";
+      a: true;
     };
     set: {
-      a: "a";
+      a: true;
     };
     map: {
-      a: "a";
-    }
+      a: true;
+    };
   };
+
+  type T = DeepOmit<Nested, Filter>;
 
   type Test = Assert<IsExact<DeepOmit<Nested, Filter>, Omitted>>;
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -158,7 +158,7 @@ function testDeepOmit() {
       };
       f: number;
     };
-    array: { a: string; b: boolean }[];
+    array: { a: string; b: boolean }[][];
     set: Set<{ a: string; b: boolean }>;
     map: Map<number, { a: string; b: boolean }>;
   };
@@ -170,7 +170,7 @@ function testDeepOmit() {
       };
       f: number;
     };
-    array: { b: boolean }[];
+    array: { b: boolean }[][];
     set: Set<{ b: boolean }>;
     map: Map<number, { b: boolean }>;
   };

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,6 +4,7 @@
 import { IsExact, AssertTrue as Assert } from "conditional-type-checks";
 import {
   DeepNonNullable,
+  DeepOmit,
   DeepPartial,
   DeepReadonly,
   DeepRequired,
@@ -145,6 +146,54 @@ function testDeepNonNullable() {
 
 function testDeepRequire() {
   type Test = Assert<IsExact<DeepRequired<ComplexNestedPartial>, ComplexNestedRequired>>;
+}
+
+function testDeepOmit() {
+  type Nested = {
+    a: {
+      b: string;
+      c: {
+        d: string;
+        e: boolean;
+      };
+      f: number;
+    };
+    array: { a: string; b: boolean }[];
+    set: Set<{ a: string; b: boolean }>;
+    map: Map<number, {a: string, b: boolean}>
+  };
+
+  type Omitted = {
+    a: {
+      c: {
+        e: boolean;
+      };
+      f: number;
+    };
+    array: { b: boolean }[];
+    set: Set<{ b: boolean }>;
+    map: Map<number, {b: boolean}>
+  };
+
+  type Filter = {
+    a: {
+      b: "b";
+      c: {
+        d: "d";
+      };
+    };
+    array: {
+      a: "a";
+    };
+    set: {
+      a: "a";
+    };
+    map: {
+      a: "a";
+    }
+  };
+
+  type Test = Assert<IsExact<DeepOmit<Nested, Filter>, Omitted>>;
 }
 
 function testTupleInference() {


### PR DESCRIPTION
Below is a simple example (which has been added to README)

Here is the `Teacher` interface.

```typescript
interface Teacher {
  name: string,
  gender: string,
  students: {name: string, score: number}[]
}
```

Now suppose you want to omit `gender` property of `Teacher`, and `score` property of `students`. You can simple define a filter type and then use `DeepOmit`.

In the filter type, the properties to be omitted completely should be defined as `true`. For the properties you want to partially omit, you should recursively define the sub-properties to be omitted.

```typescript
interface Filter {
  gender: true,
  students: {
    score: true,
  }
}

type TeacherSimple = DeepOmit<Teacher, Filter>

// The result will be:
// {
//  name: string,
//  students: {name: string}[]
// }
```

NOTE: `DeepOmit` works fine with `Array`s and `Set`s. When applied to a  `Map`, if its key and value shares common properties, both will be omitted.