### PR TITLE
Deprecate the `literal` function in favor of `as const`

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ You can also parametrize `Tuple` type with a type argument to constraint it to c
 _For TypeScript >= 3.4_: TypeScript 3.4 shipped
 [`const` assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html) which are very
 similar to our `literal` helper but also make type readonly, you should prefer `as const` construct.
+`literal` is deprecated tn `ts-essentials` 3.x, which requires TypeScript >=3.5.
 
 _For TypeScript < 3.4_: this is served as a backport of the [`const` assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html) added since TypeScript 3.4.
 

--- a/lib/functions.ts
+++ b/lib/functions.ts
@@ -6,6 +6,10 @@ export class UnreachableCaseError extends Error {
   }
 }
 
+/**
+ * @deprecated since ts-essentials 3.x -- use `as const` assertions available from TS 3.4
+ * @see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions
+ */
 export function literal<T extends Primitive>(value: T): T {
   return value;
 }


### PR DESCRIPTION
Because ts-essentials 3.x requires TS 3.5, we can mark the `literal` function as deprecated, to further encourage people to use the `as const` assertion instead. Adding this PR becasue I just was reminded of this in a review in my project :joy: 