### PR TITLE
implement PickProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npm add --save-dev ts-essentials
     - [Comparison between `Omit` and `StrictOmit`](#Comparison-between-Omit-and-StrictOmit)
   - [DeepOmit](#DeepOmit)
   - [OmitProperties](#OmitProperties)
+  - [PickProperties](#PickProperties)
   - [NonNever](#NonNever)
   - [Merge](#Merge)
   - [MarkRequired](#MarkRequired)
@@ -268,6 +269,35 @@ type ExampleWithoutMethods = OmitProperties<Example, Function>;
 type ExampleWithoutMethods = OmitProperties<Example, Function | string>;
 // Result:
 // { } (empty type)
+
+```
+
+### PickProperties
+
+Pick only properties extending type `P` in type `T`.
+
+```typescript
+interface Example {
+  log(): void;
+  version: string;
+  versionNumber: number;
+}
+
+type ExampleOnlyMethods = PickProperties<Example, Function>;
+
+// Result:
+// {
+//   log(): void;
+// }
+
+// if you want to pick multiple properties just use union type like
+
+type ExampleOnlyMethodsAndString = PickProperties<Example, Function | string>;
+// Result:
+// {
+//   log(): void;
+//   version: string;
+// }
 
 ```
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -99,6 +99,9 @@ export type StrictOmit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** Omit all properties of given type in object type */
 export type OmitProperties<T, P> = Pick<T, { [K in keyof T]: T[K] extends P ? never : K }[keyof T]>;
 
+/** Pick all properties of given type in object type */
+export type PickProperties<T, P> = Pick<T, { [K in keyof T]: T[K] extends P ? K : never }[keyof T]>;
+
 /** Recursively omit deep properties */
 export type DeepOmit<T extends DeepOmitModify<Filter>, Filter> = T extends Primitive | Function | Date
   ? T

--- a/test/index.ts
+++ b/test/index.ts
@@ -8,6 +8,7 @@ import {
   DeepPartial,
   DeepReadonly,
   DeepRequired,
+  PickProperties,
   Tuple,
   NonNever,
   Writable,
@@ -146,6 +147,11 @@ function testDeepNonNullable() {
 
 function testDeepRequire() {
   type Test = Assert<IsExact<DeepRequired<ComplexNestedPartial>, ComplexNestedRequired>>;
+}
+
+function testPickProperties() {
+  type Test1 = Assert<IsExact<PickProperties<{ a: string; b: number[] }, any[]>, { b: number[] }>>;
+  type Test2 = Assert<IsExact<PickProperties<{ a: string; b: number }, any[]>, {}>>;
 }
 
 function testDeepOmit() {


### PR DESCRIPTION
It's the opposite of OmitProperties and like omit properties it isn't straight forward for most people to implement. Example from the README.md

```typescript
interface Example {
  log(): void;
  version: string;
  versionNumber: number;
}

type ExampleOnlyMethods = PickProperties<Example, Function>;
```