### PR TITLE
add XOR type

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm install --save-dev ts-essentials
   - [ValueOf type](#ValueOf-type)
   - [AsyncOrSync type](#AsyncOrSync-type)
   - [Assertions](#Assertions)
-  _ [XOR](#XOR)
+  - [XOR](#XOR)
 - [Contributors](#Contributors)
 
 ### Basic
@@ -573,7 +573,7 @@ assert(anything instanceof String, "anything has to be a string!")
 
 ### XOR
 
-Gets the Exclusive-OR type which could make 2 types exclude each other
+Gets the XOR(Exclusive-OR) type which could make 2 types exclude each other
 ```typescript
   type A = {a: string}
   type B = {a: number; b: boolean}

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ assert(anything instanceof String, "anything has to be a string!")
 
 ### XOR
 
-Gets the XOR(Exclusive-OR) type which could make 2 types exclude each other
+Gets the XOR (Exclusive-OR) type which could make 2 types exclude each other.
 ```typescript
   type A = {a: string}
   type B = {a: number; b: boolean}

--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ Gets the XOR (Exclusive-OR) type which could make 2 types exclude each other.
   A_XOR_B = {a: 0}
   A_XOR_B = {b: true}
   A_XOR_B = {a: '', b: true}
-  A_XOR_C = {a: '', c: 0}
+  A_XOR_C = {a: '', c: 0} // would be allowed with `A | C` type
 
   // ok
   A_XOR_B = {a: 0, b: true}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npm install --save-dev ts-essentials
   - [ValueOf type](#ValueOf-type)
   - [AsyncOrSync type](#AsyncOrSync-type)
   - [Assertions](#Assertions)
+  _ [XOR](#XOR)
 - [Contributors](#Contributors)
 
 ### Basic
@@ -568,6 +569,29 @@ assert(something, "Something has to be defined!")
 const anything = "abc" as any
 assert(anything instanceof String, "anything has to be a string!")
 // from now on `anything` is string
+```
+
+### XOR
+
+Gets the Exclusive-OR type which could make 2 types exclude each other
+```typescript
+  type A = {a: string}
+  type B = {a: number; b: boolean}
+  type C = {c: number}
+
+  let A_XOR_B: XOR<A, B>
+  let A_XOR_C: XOR<A, C>
+
+  // fail
+  A_XOR_B = {a: 0}
+  A_XOR_B = {b: true}
+  A_XOR_B = {a: '', b: true}
+  A_XOR_C = {a: '', c: 0}
+
+  // ok
+  A_XOR_B = {a: 0, b: true}
+  A_XOR_B = {a: ''}
+  A_XOR_C = {c: 0}
 ```
 
 ## Contributors

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -224,3 +224,9 @@ export type ReadonlyKeys<T extends object> = {
 export type WritableKeys<T extends {}> = {
   [P in keyof T]-?: IsFullyWritable<Pick<T, P>> extends true ? P : never;
 }[keyof T];
+
+/** Mark some properties which only the former including as optional and set the value to never */
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+
+/** get the XOR type which could make 2 types exclude each other */
+export type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -229,4 +229,4 @@ export type WritableKeys<T extends {}> = {
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 
 /** get the XOR type which could make 2 types exclude each other */
-export type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
+export type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;

--- a/test/index.ts
+++ b/test/index.ts
@@ -22,7 +22,7 @@ import {
   Tuple,
   Writable,
   WritableKeys,
-  XOR
+  XOR,
 } from "../lib";
 
 type ComplexNestedPartial = {
@@ -351,15 +351,15 @@ function testAssert() {
 }
 
 function testXOR() {
-  type TestType1 = {a: string}
-  type TestType2 = {a: number; b: boolean}
-  type TestType3 = {c: number; d: boolean}
+  type TestType1 = { a: string };
+  type TestType2 = { a: number; b: boolean };
+  type TestType3 = { c: number; d: boolean };
 
-  type Actual1 = XOR<TestType1, TestType2>
-  type Expected1 = {a: string, b?: never} | {a: number, b: boolean}
+  type Actual1 = XOR<TestType1, TestType2>;
+  type Expected1 = { a: string; b?: never } | { a: number; b: boolean };
 
-  type Actual2 = XOR<TestType1, TestType3>
-  type Expected2 = {a: string, c?:never, d?: never } | {a?: never, c: number, d: boolean}
+  type Actual2 = XOR<TestType1, TestType3>;
+  type Expected2 = { a: string; c?: never; d?: never } | { a?: never; c: number; d: boolean };
 
   type Test1 = Assert<IsExact<Actual1, Expected1>>;
   type Test2 = Assert<IsExact<Actual2, Expected2>>;

--- a/test/index.ts
+++ b/test/index.ts
@@ -22,6 +22,7 @@ import {
   Tuple,
   Writable,
   WritableKeys,
+  XOR
 } from "../lib";
 
 type ComplexNestedPartial = {
@@ -347,4 +348,19 @@ function testAssert() {
   assert(anything);
   type Actual = typeof anything;
   type Test = Assert<IsExact<Actual, string>>;
+}
+
+function testXOR() {
+  type TestType1 = {a: string}
+  type TestType2 = {a: number; b: boolean}
+  type TestType3 = {c: number; d: boolean}
+
+  type Actual1 = XOR<TestType1, TestType2>
+  type Expected1 = {a: string, b?: never} | {a: number, b: boolean}
+
+  type Actual2 = XOR<TestType1, TestType3>
+  type Expected2 = {a: string, c?:never, d?: never } | {a?: never, c: number, d: boolean}
+
+  type Test1 = Assert<IsExact<Actual1, Expected1>>;
+  type Test2 = Assert<IsExact<Actual2, Expected2>>;
 }


### PR DESCRIPTION
Gets the XOR(Exclusive-OR) type which could make 2 types exclude each other
```typescript
  type A = {a: string}
  type B = {a: number; b: boolean}
  type C = {c: number}

  let A_XOR_B: XOR<A, B>
  let A_XOR_C: XOR<A, C>

  // fail
  A_XOR_B = {a: 0}
  A_XOR_B = {b: true}
  A_XOR_B = {a: '', b: true}
  A_XOR_C = {a: '', c: 0}

  // ok
  A_XOR_B = {a: 0, b: true}
  A_XOR_B = {a: ''}
  A_XOR_C = {c: 0}
```