### PR TITLE
Add SafeDictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ const dictFromUnionType: Dictionary<number, DummyOptions> = {
 // and get dictionary values
 type stringDictValues = DictionaryValues<typeof stringDict>;
 // Result: string
+
+// When building a map using JS objects consider using SafeDictionary
+const safeDict: SafeDictionary<number> = {}
+const value: number | undefined = safeDict['foo']
 ```
 
 ### Deep Partial & Deep Required & Deep Readonly & Deep NonNullable

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,11 +13,15 @@ export type IsTuple<T> = T extends [infer A]
   ? T
   : never;
 
-/** Dictionaries related */
+/** Like Record, but can be used with only one argument */
 export type Dictionary<T, K extends string | number = string> = { [key in K]: T };
+/** Given Dictionary<T> returns T */
 export type DictionaryValues<T> = T extends Dictionary<infer U> ? U : never;
-// SafeDictionary does not have a second argument, because
-// Dictionary<T, 'a' | 'b'> enforces the existence of those keys.
+/**
+ * Like Dictionary, but ensures type safety of index access.
+ * Does not not have a second argument, because using Dictionary<T, 'a' | 'b'>
+ * already enforces that all of the keys are present.
+ */
 export type SafeDictionary<T> = Dictionary<T | undefined>;
 
 /** Like Partial but recursive */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -16,6 +16,9 @@ export type IsTuple<T> = T extends [infer A]
 /** Dictionaries related */
 export type Dictionary<T, K extends string | number = string> = { [key in K]: T };
 export type DictionaryValues<T> = T extends Dictionary<infer U> ? U : never;
+// SafeDictionary does not have a second argument, because
+// Dictionary<T, 'a' | 'b'> enforces the existence of those keys.
+export type SafeDictionary<T> = Dictionary<T | undefined>;
 
 /** Like Partial but recursive */
 export type DeepPartial<T> = T extends Builtin

--- a/test/index.ts
+++ b/test/index.ts
@@ -12,6 +12,8 @@ import {
   DeepReadonly,
   DeepRequired,
   DeepWritable,
+  Dictionary,
+  DictionaryValues,
   MarkOptional,
   MarkRequired,
   Merge,
@@ -19,11 +21,39 @@ import {
   NonNever,
   PickProperties,
   ReadonlyKeys,
+  SafeDictionary,
   Tuple,
   Writable,
   WritableKeys,
   XOR,
 } from "../lib";
+
+function testDictionary() {
+  const dict: Dictionary<number> = null as any;
+  type Test = Assert<IsExact<typeof dict["foo"], number>>;
+}
+
+function testDictionaryTwoArguments() {
+  const dict: Dictionary<number, "a" | "b"> = null as any;
+  type Test = Assert<IsExact<typeof dict["a"], number>>;
+}
+
+function testDictionaryValues() {
+  type Test = Assert<IsExact<DictionaryValues<Dictionary<number>>, number>>;
+}
+
+function testDictionaryValuesTwoArguments() {
+  type Test = Assert<IsExact<DictionaryValues<Dictionary<number, "a" | "b">>, number>>;
+}
+
+function testSafeDictionary() {
+  const dict: SafeDictionary<number> = null as any;
+  type Test = Assert<IsExact<typeof dict["foo"], number | undefined>>;
+}
+
+function testSafeDictionaryValues() {
+  type Test = Assert<IsExact<DictionaryValues<SafeDictionary<number>>, number | undefined>>;
+}
 
 type ComplexNestedPartial = {
   simple?: number;


### PR DESCRIPTION
This PR introduces `SafeDictionary`. It differs from `Dictionary` in that it enforces type safety on the values. Similarly to `new Map<string, number>().get('foo')` the code `const x: SafeDictionary<number> = {}; x['foo']` is typed as `number | undefined`