### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+package-lock.json
+.idea


### PR DESCRIPTION
- `package-lock.json` is not used (`yarn.lock` is used instead) so imho we should ignore it
- `.idea` is automatically generated by all IntelliJ-based IDEs (e.g. Webstorm)