### PR TITLE
allow SafeDictionary<T, number>

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,10 +19,10 @@ export type Dictionary<T, K extends string | number = string> = { [key in K]: T 
 export type DictionaryValues<T> = T extends Dictionary<infer U> ? U : never;
 /**
  * Like Dictionary, but ensures type safety of index access.
- * Does not not have a second argument, because using Dictionary<T, 'a' | 'b'>
- * already enforces that all of the keys are present.
+ * Note that only using an infinite type (`string` or `number`) as key type makes sense here,
+ * because using `Dictionary<T, 'a' | 'b'>` already enforces that all of the keys are present.
  */
-export type SafeDictionary<T> = Dictionary<T | undefined>;
+export type SafeDictionary<T, K extends string | number = string> = Dictionary<T | undefined, K>;
 
 /** Like Partial but recursive */
 export type DeepPartial<T> = T extends Builtin

--- a/test/index.ts
+++ b/test/index.ts
@@ -52,6 +52,11 @@ function testSafeDictionary() {
   type Test = Assert<IsExact<typeof dict["foo"], number | undefined>>;
 }
 
+function testSafeDictionaryByNumber() {
+  const dict: SafeDictionary<boolean, number> = null as any;
+  type Test = Assert<IsExact<typeof dict[42], boolean | undefined>>;
+}
+
 function testSafeDictionaryValues() {
   type Test = Assert<IsExact<DictionaryValues<SafeDictionary<number>>, number | undefined>>;
 }


### PR DESCRIPTION
`SafeDictionary` is a really great recent addition, but I found out that omitting the `K` param is actually insufficient -- I'm using `Dictionary<T, number>` in multiple places, and I'd like to switch them too to the safe variant.

CC @sz-piotr since you've introduced this.