### PR TITLE
Simplify Merge type

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -233,7 +233,7 @@ export type NonNever<T extends {}> = Pick<T, { [K in keyof T]: T[K] extends neve
 export type NonEmptyObject<T extends {}> = keyof T extends never ? never : T;
 
 /** Merge 2 types, properties types from the latter override the ones defined on the former type */
-export type Merge<M, N> = Omit<M, Extract<keyof M, keyof N>> & N;
+export type Merge<M, N> = Omit<M, keyof N> & N;
 
 /** Mark some properties as required, leaving others unchanged */
 export type MarkRequired<T, RK extends keyof T> = Exclude<T, RK> & Required<Pick<T, RK>>;


### PR DESCRIPTION
Merge type could be simplified. This is the definition of TypeScript's built-in Extract type: 
```
type Extract<T, U> = T extends U ? T : never;
```
That's why these types are equal
```
type Test = Extract<'id' | 'name' | 'age', 'id' | 'name'>; // Equals to 'id' | 'name'
type Test2 = 'id' | 'name' // Equals 'id' | 'name'
```