### PR TITLE
Proposal: format dist/*.d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "license": "MIT",
   "scripts": {
     "build": "rm -rf ./dist && tsc -p tsconfig.prod.json --outDir ./dist",
-    "prepublishOnly": "yarn test && yarn build",
+    "formatDeclarations": "prettier --ignore-path *.js --write dist/*.d.ts",
+    "prepublishOnly": "yarn test && yarn build && yarn formatDeclarations",
     "test": "prettier -c **/*.ts && tsc --noEmit",
     "test:fix": "prettier --write **/*.ts && tsc --noEmit"
   },


### PR DESCRIPTION
Rationale: improved DX -- if `dist/types.d.ts` is formatted, using a ts-essentials type you can click "go to declaration" in the editor and examine the details, without leaving your editor to check the docs etc. The currently shipped compiled version doesn't include whitespace so it's unreadable.

Drawbacks: the additional whitespace bumps the `types.d.ts` file size by ~10%.
```
   0[quezak@...]~/src/ts-essentials>: ls -lh dist/*.d.ts
-rw-r--r-- 1 quezak quezak  229 03-31 11:26 dist/functions.d.ts
-rw-r--r-- 1 quezak quezak   54 03-31 11:26 dist/index.d.ts
-rw-r--r-- 1 quezak quezak 9.9K 03-31 11:26 dist/types.d.ts
   0[quezak@...]~/src/ts-essentials>: yarn formatDeclarations
...
   0[quezak@...]~/src/ts-essentials>: ls -lh dist/*.d.ts
-rw-r--r-- 1 quezak quezak 227 03-31 11:27 dist/functions.d.ts
-rw-r--r-- 1 quezak quezak  54 03-31 11:26 dist/index.d.ts
-rw-r--r-- 1 quezak quezak 11K 03-31 11:27 dist/types.d.ts
```

Question: is the readability bonus worth the increased file size?