### PR TITLE
Do not require using all SafeDictionary keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ type stringDictValues = DictionaryValues<typeof stringDict>;
 // When building a map using JS objects consider using SafeDictionary
 const safeDict: SafeDictionary<number> = {}
 const value: number | undefined = safeDict['foo']
+
+// ...or OptionalDictionary
+type ConfigKeys = 'LOGLEVEL' | 'PORT' | 'DEBUG';
+const optionalDict: OptionalDictionary<string, ConfigKeys> = {
+  LOGLEVEL: 'INFO',
+}
+const port: string | undefined = optionalDict['PORT'];
 ```
 
 ### Deep* wrapper types

--- a/README.md
+++ b/README.md
@@ -101,12 +101,20 @@ type stringDictValues = DictionaryValues<typeof stringDict>;
 const safeDict: SafeDictionary<number> = {}
 const value: number | undefined = safeDict['foo']
 
-// ...or OptionalDictionary
+// With SafeDictionary you don't need to use all of the sub-types of a finite type.
+// If you care about the key exhaustiveness, use a regular Dictionary.
 type ConfigKeys = 'LOGLEVEL' | 'PORT' | 'DEBUG';
-const optionalDict: OptionalDictionary<string, ConfigKeys> = {
-  LOGLEVEL: 'INFO',
+const configSafeDict: SafeDictionary<number, ConfigKeys> = {
+  LOGLEVEL: 2,
 }
-const port: string | undefined = optionalDict['PORT'];
+const maybePort: number | undefined = configSafeDict['PORT'];
+
+const configDict: Dictionary<number, ConfigKeys> = {
+  LOGLEVEL: 2,
+  PORT: 8080,
+  DEBUG: 1,
+}
+const port: number = configDict['PORT'];
 ```
 
 ### Deep\* wrapper types

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -24,6 +24,8 @@ export type DictionaryValues<T> = T extends Dictionary<infer U> ? U : never;
  * because using `Dictionary<T, 'a' | 'b'>` already enforces that all of the keys are present.
  */
 export type SafeDictionary<T, K extends string | number = string> = Dictionary<T | undefined, K>;
+/** Like SafeDictionary, but not require key exhaustiveness */
+export type OptionalDictionary<T, K extends string | number = string> = { [key in K]?: T };
 
 /** Like Partial but recursive */
 export type DeepPartial<T> = T extends Builtin

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,7 +14,7 @@ export type IsTuple<T> = T extends [infer A]
   : never;
 export type AnyArray<T = any> = Array<T> | ReadonlyArray<T>;
 
-/** 
+/**
  * Like Record, but can be used with only one argument.
  * Useful, if you want to make sure that all of the keys of a finite type are used.
  */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,18 +14,19 @@ export type IsTuple<T> = T extends [infer A]
   : never;
 export type AnyArray<T = any> = Array<T> | ReadonlyArray<T>;
 
-/** Like Record, but can be used with only one argument */
+/** 
+ * Like Record, but can be used with only one argument.
+ * Useful, if you want to make sure that all of the keys of a finite type are used.
+ */
 export type Dictionary<T, K extends string | number = string> = { [key in K]: T };
 /** Given Dictionary<T> returns T */
 export type DictionaryValues<T> = T extends Dictionary<infer U> ? U : never;
 /**
- * Like Dictionary, but ensures type safety of index access.
- * Note that only using an infinite type (`string` or `number`) as key type makes sense here,
- * because using `Dictionary<T, 'a' | 'b'>` already enforces that all of the keys are present.
+ * Like Dictionary, but:
+ *  - ensures type safety of index access
+ *  - does not enforce key exhaustiveness
  */
-export type SafeDictionary<T, K extends string | number = string> = Dictionary<T | undefined, K>;
-/** Like SafeDictionary, but not require key exhaustiveness */
-export type OptionalDictionary<T, K extends string | number = string> = { [key in K]?: T };
+export type SafeDictionary<T, K extends string | number = string> = { [key in K]?: T };
 
 /** Like Partial but recursive */
 export type DeepPartial<T> = T extends Builtin

--- a/test/index.ts
+++ b/test/index.ts
@@ -31,7 +31,6 @@ import {
   Tail,
   Exact,
   ElementOf,
-  OptionalDictionary,
   DeepUndefinable,
   OptionalKeys,
   RequiredKeys,
@@ -55,6 +54,12 @@ function testDictionaryValuesTwoArguments() {
   type Test = Assert<IsExact<DictionaryValues<Dictionary<number, "a" | "b">>, number>>;
 }
 
+function testDictionaryFiniteTypeExhaustiveness() {
+  type TestType = 'A' | 'B';
+  // @ts-expect-error 
+  const dict: Dictionary<string, TestType> = { A: 'NOT-OK' }
+}
+
 function testSafeDictionary() {
   const dict: SafeDictionary<number> = null as any;
   type Test = Assert<IsExact<typeof dict["foo"], number | undefined>>;
@@ -69,9 +74,9 @@ function testSafeDictionaryValues() {
   type Test = Assert<IsExact<DictionaryValues<SafeDictionary<number>>, number | undefined>>;
 }
 
-function testOptionalDictionary() {
-  const dict: OptionalDictionary<number, "a" | "b"> = { a: 1 };
-  type Test = Assert<IsExact<typeof dict["b"], number | undefined>>;
+function testSafeDictionaryFiniteTypeNonExhaustiveness() {
+  type TestType = 'A' | 'B';
+  const safeDict: SafeDictionary<string, TestType> = { A: 'OK' }
 }
 
 type ComplexNestedPartial = {

--- a/test/index.ts
+++ b/test/index.ts
@@ -55,9 +55,9 @@ function testDictionaryValuesTwoArguments() {
 }
 
 function testDictionaryFiniteTypeExhaustiveness() {
-  type TestType = 'A' | 'B';
-  // @ts-expect-error 
-  const dict: Dictionary<string, TestType> = { A: 'NOT-OK' }
+  type TestType = "A" | "B";
+  // @ts-expect-error
+  const dict: Dictionary<string, TestType> = { A: "NOT-OK" };
 }
 
 function testSafeDictionary() {
@@ -75,8 +75,8 @@ function testSafeDictionaryValues() {
 }
 
 function testSafeDictionaryFiniteTypeNonExhaustiveness() {
-  type TestType = 'A' | 'B';
-  const safeDict: SafeDictionary<string, TestType> = { A: 'OK' }
+  type TestType = "A" | "B";
+  const safeDict: SafeDictionary<string, TestType> = { A: "OK" };
 }
 
 type ComplexNestedPartial = {

--- a/test/index.ts
+++ b/test/index.ts
@@ -54,12 +54,6 @@ function testDictionaryValuesTwoArguments() {
   type Test = Assert<IsExact<DictionaryValues<Dictionary<number, "a" | "b">>, number>>;
 }
 
-function testDictionaryFiniteTypeExhaustiveness() {
-  type TestType = "A" | "B";
-  // @ts-expect-error
-  const dict: Dictionary<string, TestType> = { A: "NOT-OK" };
-}
-
 function testSafeDictionary() {
   const dict: SafeDictionary<number> = null as any;
   type Test = Assert<IsExact<typeof dict["foo"], number | undefined>>;

--- a/test/index.ts
+++ b/test/index.ts
@@ -32,6 +32,7 @@ import {
   Tail,
   Exact,
   ElementOf,
+  OptionalDictionary,
 } from "../lib";
 
 function testDictionary() {
@@ -64,6 +65,11 @@ function testSafeDictionaryByNumber() {
 
 function testSafeDictionaryValues() {
   type Test = Assert<IsExact<DictionaryValues<SafeDictionary<number>>, number | undefined>>;
+}
+
+function testOptionalDictionary() {
+  const dict: OptionalDictionary<number, "a" | "b"> = { a: 1 };
+  type Test = Assert<IsExact<typeof dict["b"], number | undefined>>;
 }
 
 type ComplexNestedPartial = {


### PR DESCRIPTION
Presenting:
```typescript
type OptionalDictionary<T, K extends string | number = string> = { [key in K]?: T };
```
a weaker version of `SafeDictionary<T, K>` -- if the `K` type is **not infinite** you **do not** have to use all its union elements.

```typescript
enum MetadataKeys = {
  NAME = 'NAME',
  AUTHOR = 'AUTHOR',
  TIMESTAMP = 'TIMESTAMP',
}
const metadata: OptionalDictionary<string, MetadataKeys> = {
  AUTHOR: 'akwodkiewicz@gmail.com',
}

// whereas:

const badMetadata: SafeDictionary<string, MetadataKeys> = {
  AUTHOR: 'akwodkiewicz@gmail.com',
}
/// Error:
/// Type '{ AUTHOR: string; }' is missing the following properties
/// from type 'Dictionary<string | undefined, MetadataKeys>': NAME, TIMESTAMP
```
There is no optional version of _non-safe_ `Dictionary`, because the optionality of keys makes the return type implicitly `T | undefined`.