### PR TITLE
Add DeepUndefinable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npm install --save-dev ts-essentials
     - DeepReadonly
     - DeepNonNullable
     - DeepNullable
+    - DeepUndefinable
   - [Writable & DeepWritable](#Writable)
   - [Buildable](#Buildable)
   - [Omit](#Omit)
@@ -105,6 +106,7 @@ const value: number | undefined = safeDict['foo']
 - DeepReadonly
 - DeepNonNullable
 - DeepNullable
+- DeepUndefinable
 
 *keywords: recursive, nested, optional*
 
@@ -167,6 +169,23 @@ const sampleDeepNullable2: ComplexObjectNullable = {
     // error -- property `a` missing, should be `number | null`
   }
 }
+
+type ComplexObjectUndefinable = DeepUndefinable<ComplexObject>;
+const sampleDeepUndefinable1: ComplexObjectUndefinable = {
+  simple: undefined,
+  nested: {
+    a: undefined,
+    array: [{ bar: undefined }]
+  }
+}
+const sampleDeepUndefinable2: ComplexObjectUndefinable = {
+  // error -- property `simple` missing, should be `number | undefined`
+  nested: {
+    array: [[{ bar: undefined }]]
+    // error -- property `a` missing, should be `string | undefined`
+  }
+}
+
 ```
 
 ### Writable

--- a/README.md
+++ b/README.md
@@ -170,12 +170,18 @@ const sampleDeepNullable2: ComplexObjectNullable = {
   }
 }
 
+// DeepUndefinable will come in handy if:
+//  - you want to explicitly assign values to all of the properties
+//  AND
+//  - the expression used for the assignment can return an `undefined` value
+// In most situations DeepPartial will suffice.
+declare function tryGet(name: string): string | undefined;
 type ComplexObjectUndefinable = DeepUndefinable<ComplexObject>;
 const sampleDeepUndefinable1: ComplexObjectUndefinable = {
   simple: undefined,
   nested: {
-    a: undefined,
-    array: [{ bar: undefined }]
+    a: tryGet('a-value'),
+    array: [{ bar: tryGet('bar-value') }]
   }
 }
 const sampleDeepUndefinable2: ComplexObjectUndefinable = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -71,6 +71,27 @@ export type DeepNullable<T> = T extends Builtin
   ? { [K in keyof T]: DeepNullable<T[K]> }
   : T | null;
 
+/** Recursive undefinable */
+export type DeepUndefinable<T> = T extends Builtin
+  ? T | undefined
+  : T extends Map<infer K, infer V>
+  ? Map<DeepUndefinable<K>, DeepUndefinable<V>>
+  : T extends WeakMap<infer K, infer V>
+  ? WeakMap<DeepUndefinable<K>, DeepUndefinable<V>>
+  : T extends Set<infer U>
+  ? Set<DeepUndefinable<U>>
+  : T extends WeakSet<infer U>
+  ? WeakSet<DeepUndefinable<U>>
+  : T extends Array<infer U>
+  ? T extends IsTuple<T>
+    ? { [K in keyof T]: DeepUndefinable<T[K]> | undefined }
+    : Array<DeepUndefinable<U>>
+  : T extends Promise<infer U>
+  ? Promise<DeepUndefinable<U>>
+  : T extends {}
+  ? { [K in keyof T]: DeepUndefinable<T[K]> }
+  : T | undefined;
+
 /** Like NonNullable but recursive */
 export type DeepNonNullable<T> = T extends Builtin
   ? NonNullable<T>

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,7 +1,7 @@
 /**
  * This file contains a lot of unused functions as it's only typechecked.
  */
-import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
+import { AssertTrue as Assert, IsExact, AssertFalse } from "conditional-type-checks";
 
 import {
   assert,
@@ -32,6 +32,7 @@ import {
   Tail,
   Exact,
   ElementOf,
+  DeepUndefinable,
 } from "../lib";
 
 function testDictionary() {
@@ -113,6 +114,19 @@ type ComplexNestedNullable = {
     set: Set<{ name: string | null }>;
     map: Map<string | null, { name: string | null }>;
     promise: Promise<{ foo: string | null; bar: number | null }>;
+  };
+};
+
+type ComplexNestedUndefinable = {
+  simple: number | undefined;
+  nested: {
+    date: Date | undefined;
+    func: (() => string) | undefined;
+    array: { bar: number | undefined }[];
+    tuple: [string | undefined, number | undefined, { good: boolean | undefined } | undefined];
+    set: Set<{ name: string | undefined }>;
+    map: Map<string | undefined, { name: string | undefined }>;
+    promise: Promise<{ foo: string | undefined; bar: number | undefined }>;
   };
 };
 
@@ -239,8 +253,27 @@ type SimpleTypeNullable = {
   };
 };
 
+type SimpleTypeUndefinable = {
+  field1: string | undefined;
+  field2: string | undefined;
+  field3: {
+    field4: string | undefined;
+    field5: number | undefined;
+    field6: {
+      field7: number | undefined;
+      field8: string | undefined;
+    };
+  };
+};
+
 function testDeepNullable2() {
   type Test = Assert<IsExact<DeepNullable<SimpleType>, SimpleTypeNullable>>;
+}
+
+function testDeepUndefinable() {
+  type Test1 = AssertFalse<IsExact<DeepUndefinable<SimpleType>, DeepPartial<SimpleType>>>;
+  type Test2 = Assert<IsExact<DeepUndefinable<SimpleType>, SimpleTypeUndefinable>>;
+  type Test3 = Assert<IsExact<DeepUndefinable<ComplexNestedRequired>, ComplexNestedUndefinable>>;
 }
 
 function testDeepNonNullable() {


### PR DESCRIPTION
Presenting:

```typescript
/** Recursive undefinable */
export type DeepUndefinable<T> = T extends Builtin
  ? T | undefined
  : T extends Map<infer K, infer V>
  ? Map<DeepUndefinable<K>, DeepUndefinable<V>>
  : T extends WeakMap<infer K, infer V>
  ? WeakMap<DeepUndefinable<K>, DeepUndefinable<V>>
  : T extends Set<infer U>
  ? Set<DeepUndefinable<U>>
  : T extends WeakSet<infer U>
  ? WeakSet<DeepUndefinable<U>>
  : T extends Array<infer U>
  ? T extends IsTuple<T>
    ? { [K in keyof T]: DeepUndefinable<T[K]> | undefined }
    : Array<DeepUndefinable<U>>
  : T extends Promise<infer U>
  ? Promise<DeepUndefinable<U>>
  : T extends {}
  ? { [K in keyof T]: DeepUndefinable<T[K]> }
  : T | undefined;
```

This behaves exactly like `DeepNullable`, except it makes every type _undefinable_ instead of _nullable_.

Keep in mind that this is different to `DeepPartial`, because `DeepUndefinable` requires an explicit assignment to `undefined` instead of allowing to skip the key.

#### Example
```typescript
interface Style {
  colour: string;
  margin: {
    vertical: string;
    horizontal: string
  }
}

declare function tryGet(name: string): string | undefined;

function getNewStyle(): DeepUndefinable<Style> {
  return {
    colour: tryGet('colour'),
    margin: {
      vertical: tryGet('margin-vertical'),
      horizontal: tryGet('margin-horizontal'),
    },
  };
}

function badGetNewStyle(): DeepUndefinable<Style> {
  return {
    colour: tryGet('colour'),
    margin: {
      // vertical: tryGet('margin-vertical'),
      horizontal: tryGet('margin-horizontal'),
    },
  };
}
/// Error
/// Property 'vertical' is missing in type
/// '{ horizontal: string | undefined; }'
/// but required in type
/// '{ vertical: string | undefined; horizontal: string | undefined; }
```