### PR TITLE
fix #118, keep optional flag in DeepOmit members

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ Gets keys of an object which are optional.
 type T = {
   a: number;
   b?: string;
-  c: string;
+  c: string | undefined;
   d?: string;
 };
 type Result = OptionalKeys<T>;
@@ -522,7 +522,7 @@ Gets keys of an object which are required.
 type T = {
   a: number;
   b?: string;
-  c: string;
+  c: string | undefined;
   d?: string;
 };
 type Result = OptionalKeys<T>;

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 npm install --save-dev ts-essentials
 ```
 
-👉 We require `typescript>=3.7`. If you're looking for support for older TS versions use `ts-essentials@3` (for 3.6>=) or `ts-essentials@2` instead.
+👉 We require `typescript>=3.7`. If you're looking for support for older TS versions use `ts-essentials@3` (for 3.6>=)
+or `ts-essentials@2` instead.
 
 ## What's inside?
 
@@ -25,7 +26,7 @@ npm install --save-dev ts-essentials
 - [What's inside?](#Whats-inside)
   - [Basic](#Basic)
   - [Dictionaries](#Dictionaries)
-  - [Deep* wrapper types](#Deep-wrapper-types)
+  - [Deep\* wrapper types](#Deep-wrapper-types)
     - DeepPartial
     - DeepRequired
     - DeepReadonly
@@ -45,6 +46,8 @@ npm install --save-dev ts-essentials
   - [MarkOptional](#MarkOptional)
   - [ReadonlyKeys](#ReadonlyKeys)
   - [WritableKeys](#WritableKeys)
+  - [OptionalKeys](#OptionalKeys)
+  - [RequiredKeys](#RequiredKeys)
   - [UnionToIntersection](#UnionToIntersection)
   - [Opaque types](#Opaque-types)
   - [Tuple constraint](#Tuple-constraint)
@@ -67,7 +70,7 @@ npm install --save-dev ts-essentials
 
 ### Dictionaries
 
-*keywords: map*
+_keywords: map_
 
 ```typescript
 const stringDict: Dictionary<string> = {
@@ -94,11 +97,11 @@ type stringDictValues = DictionaryValues<typeof stringDict>;
 // Result: string
 
 // When building a map using JS objects consider using SafeDictionary
-const safeDict: SafeDictionary<number> = {}
-const value: number | undefined = safeDict['foo']
+const safeDict: SafeDictionary<number> = {};
+const value: number | undefined = safeDict["foo"];
 ```
 
-### Deep* wrapper types
+### Deep\* wrapper types
 
 - DeepPartial
 - DeepRequired
@@ -106,7 +109,7 @@ const value: number | undefined = safeDict['foo']
 - DeepNonNullable
 - DeepNullable
 
-*keywords: recursive, nested, optional*
+_keywords: recursive, nested, optional_
 
 ```typescript
 type ComplexObject = {
@@ -149,24 +152,24 @@ const sampleNonNullable: ComplexObjectNonNullable = {
   nested: {
     a: "test",
     array: [{ bar: null }], // Error: Type 'null' is not assignable to type 'number'
-  }
-}
+  },
+};
 
 type ComplexObjectNullable = DeepNullable<ComplexObject>;
 const sampleDeepNullable1: ComplexObjectNullable = {
   simple: null,
   nested: {
     a: null,
-    array: [{ bar: null }]
-  }
-}
+    array: [{ bar: null }],
+  },
+};
 const sampleDeepNullable2: ComplexObjectNullable = {
   simple: 1,
   nested: {
-    array: [null]  // OK
+    array: [null], // OK
     // error -- property `a` missing, should be `number | null`
-  }
-}
+  },
+};
 ```
 
 ### Writable
@@ -206,24 +209,25 @@ test[0].bar.x = 2;
 
 ### Buildable
 
-*keywords: builder*
+_keywords: builder_
 
-A combination of both `DeepWritable` and `DeepPartial`.
-This type allows building an object step-by-step by assigning values to its attributes in multiple statements.
+A combination of both `DeepWritable` and `DeepPartial`. This type allows building an object step-by-step by assigning
+values to its attributes in multiple statements.
 
 ```typescript
-interface ReadonlyObject extends Readonly<{
-  simple: number;
-  nested: Readonly<{
-    a: string;
-    array: ReadonlyArray<Readonly<{ bar: number }>>;
-  }>;
-}> {}
+interface ReadonlyObject
+  extends Readonly<{
+    simple: number;
+    nested: Readonly<{
+      a: string;
+      array: ReadonlyArray<Readonly<{ bar: number }>>;
+    }>;
+  }> {}
 
 const buildable: Buildable<ReadonlyObject> = {};
 buildable.simple = 7;
 buildable.nested = {};
-buildable.nested.a = 'test';
+buildable.nested.a = "test";
 buildable.nested.array = [];
 buildable.nested.array.push({ bar: 1 });
 const finished = buildable as ReadonlyObject;
@@ -286,23 +290,28 @@ Here is the `Teacher` interface.
 
 ```typescript
 interface Teacher {
-  name: string,
-  gender: string,
-  students: {name: string, score: number}[]
+  name: string;
+  gender: string;
+  students: { name: string; score: number }[];
 }
 ```
 
-Now suppose you want to omit `gender` property of `Teacher`, and `score` property of `students`. You can achieve this with a simple type filter.
+Now suppose you want to omit `gender` property of `Teacher`, and `score` property of `students`. You can achieve this
+with a simple type filter.
 
-In the filter, the properties to be omitted completely should be defined as `never`. For the properties you want to partially omit, you should recursively define the sub-properties to be omitted.
+In the filter, the properties to be omitted completely should be defined as `never`. For the properties you want to
+partially omit, you should recursively define the sub-properties to be omitted.
 
 ```typescript
-type TeacherSimple = DeepOmit<Teacher, {
-  gender: never,
-  students: {
-    score: never,
+type TeacherSimple = DeepOmit<
+  Teacher,
+  {
+    gender: never;
+    students: {
+      score: never;
+    };
   }
-}>
+>;
 
 // The result will be:
 // {
@@ -318,7 +327,7 @@ NOTE
 
 ### OmitProperties
 
-*keywords: filter, props*
+_keywords: filter, props_
 
 Removes all properties extending type `P` in type `T`. NOTE: it works opposite to filtering.
 
@@ -340,7 +349,6 @@ type ExampleWithoutMethods = OmitProperties<Example, Function>;
 type ExampleWithoutMethods = OmitProperties<Example, Function | string>;
 // Result:
 // { } (empty type)
-
 ```
 
 ### PickProperties
@@ -369,7 +377,6 @@ type ExampleOnlyMethodsAndString = PickProperties<Example, Function | string>;
 //   log(): void;
 //   version: string;
 // }
-
 ```
 
 ### NonNever
@@ -392,7 +399,7 @@ Useful for accepting only objects with keys, great after a filter like OmitPrope
 type NumberDictionary<T> = NonEmptyObject<PickProperties<T, number>>;
 
 // return { a: number }
-type SomeObject = NumberDictionary<{ a: number, b: string }>;
+type SomeObject = NumberDictionary<{ a: number; b: string }>;
 
 // return never
 type EmptyObject = NumberDictionary<{}>;
@@ -400,7 +407,7 @@ type EmptyObject = NumberDictionary<{}>;
 
 ### Merge
 
-*keywords: override*
+_keywords: override_
 
 ```typescript
 type Foo = {
@@ -422,8 +429,8 @@ const xyz: Merge<Foo, Bar> = { a: 4, b: 2 };
 
 ### MarkRequired
 
-Useful when you're sure some optional properties will be set. A real life example: when selecting
-an object with its related entities from an ORM.
+Useful when you're sure some optional properties will be set. A real life example: when selecting an object with its
+related entities from an ORM.
 
 ```typescript
 class User {
@@ -431,11 +438,11 @@ class User {
   posts?: Post[];
   photos?: Photo[];
 }
-type UserWithPosts = MarkRequired<User, 'posts'>;
+type UserWithPosts = MarkRequired<User, "posts">;
 
 // example usage with a TypeORM repository -- `posts` are now required, `photos` are still optional
 async function getUserWithPosts(id: number): Promise<UserWithPosts> {
-  return userRepo.findOneOrFail({ id }, { relations: ['posts'] }) as Promise<UserWithPosts>;
+  return userRepo.findOneOrFail({ id }, { relations: ["posts"] }) as Promise<UserWithPosts>;
 }
 ```
 
@@ -451,7 +458,7 @@ interface User {
   password: string;
 }
 
-type UserWithoutPassword = MarkOptional<User, 'password'>;
+type UserWithoutPassword = MarkOptional<User, "password">;
 
 // Result:
 
@@ -461,7 +468,6 @@ type UserWithoutPassword = MarkOptional<User, 'password'>;
 //   email: string;
 //   password?: string;
 // }
-
 ```
 
 ### ReadonlyKeys
@@ -473,7 +479,7 @@ type T = {
   readonly a: number;
   b: string;
 };
-type Result = ReadonlyKeys<T>
+type Result = ReadonlyKeys<T>;
 // Result:
 // "a"
 ```
@@ -487,9 +493,41 @@ type T = {
   readonly a: number;
   b: string;
 };
-type Result = WritableKeys<T>
+type Result = WritableKeys<T>;
 // Result:
 // "b"
+```
+
+### OptionalKeys
+
+Gets keys of an object which are optional.
+
+```typescript
+type T = {
+  a: number;
+  b?: string;
+  c: string;
+  d?: string;
+};
+type Result = OptionalKeys<T>;
+// Result:
+// "b" | "d"
+```
+
+### RequiredKeys
+
+Gets keys of an object which are required.
+
+```typescript
+type T = {
+  a: number;
+  b?: string;
+  c: string;
+  d?: string;
+};
+type Result = OptionalKeys<T>;
+// Result:
+// "a" | "c"
 ```
 
 ### UnionToIntersection
@@ -600,24 +638,26 @@ class Travis implements CiProvider {
 
 ### Assertions
 
-*keywords: invariant*
+_keywords: invariant_
 
-Simple runtime assertion that narrows involved types using [assertion functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions).
+Simple runtime assertion that narrows involved types using
+[assertion functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions).
 
 Note: This function is not purely type level and leaves minimal runtime trace in generated code.
 
 ```typescript
-const something: string | undefined = "abc" as any
-assert(something, "Something has to be defined!")
+const something: string | undefined = "abc" as any;
+assert(something, "Something has to be defined!");
 // from now on `something` is string, if this wouldn't be a case, assert would throw
 
-const anything = "abc" as any
-assert(anything instanceof String, "anything has to be a string!")
+const anything = "abc" as any;
+assert(anything instanceof String, "anything has to be a string!");
 // from now on `anything` is string
 ```
 
 ### Exact
-*keywords: same, equals, equality*
+
+_keywords: same, equals, equality_
 
 `Exact<TYPE, SHAPE>` Checks if `TYPE` is exactly the same as `SHAPE`, if yes than `TYPE` is returned otherwise `never`.
 
@@ -635,23 +675,23 @@ Exact<C, C> // returns C
 Gets the XOR (Exclusive-OR) type which could make 2 types exclude each other.
 
 ```typescript
-  type A = {a: string}
-  type B = {a: number; b: boolean}
-  type C = {c: number}
+type A = { a: string };
+type B = { a: number; b: boolean };
+type C = { c: number };
 
-  let A_XOR_B: XOR<A, B>
-  let A_XOR_C: XOR<A, C>
+let A_XOR_B: XOR<A, B>;
+let A_XOR_C: XOR<A, C>;
 
-  // fail
-  A_XOR_B = {a: 0}
-  A_XOR_B = {b: true}
-  A_XOR_B = {a: '', b: true}
-  A_XOR_C = {a: '', c: 0} // would be allowed with `A | C` type
+// fail
+A_XOR_B = { a: 0 };
+A_XOR_B = { b: true };
+A_XOR_B = { a: "", b: true };
+A_XOR_C = { a: "", c: 0 }; // would be allowed with `A | C` type
 
-  // ok
-  A_XOR_B = {a: 0, b: true}
-  A_XOR_B = {a: ''}
-  A_XOR_C = {c: 0}
+// ok
+A_XOR_B = { a: 0, b: true };
+A_XOR_B = { a: "" };
+A_XOR_C = { c: 0 };
 ```
 
 ### Functional type essentials
@@ -663,8 +703,9 @@ function tail<T extends any[]>(array: T): Tail<T> {
   return array.slice(1) as Tail<T>;
 }
 
-type FirstParameter<FnT extends (...args: any) => any> =
-  FnT extends ((...args: infer ArgsT) => any) ? Head<ArgsT> : never;
+type FirstParameter<FnT extends (...args: any) => any> = FnT extends (...args: infer ArgsT) => any
+  ? Head<ArgsT>
+  : never;
 ```
 
 ## Contributors
@@ -710,6 +751,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome! [Read more](./CONTRIBUTING.md)
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification.
+Contributions of any kind welcome! [Read more](./CONTRIBUTING.md)

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -211,6 +211,8 @@ export type DeepOmit<T extends DeepOmitModify<Filter>, Filter> = T extends Built
   ? ItemType extends DeepOmitModify<Filter>
     ? Promise<DeepOmit<ItemType, Filter>>
     : T
+  // explicitly mentioning optional properties, to work around TS making them required
+  // see https://github.com/krzkaczor/ts-essentials/issues/118
   : { [K in Exclude<OptionalKeys<T>, keyof Filter>]+?: T[K] } &
       OmitProperties<
         {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -179,6 +179,8 @@ export type OptionalKeys<T> = {
 export type RequiredKeys<T> = Exclude<keyof T, OptionalKeys<T>>;
 
 /** Recursively omit deep properties */
+// explicitly mentioning optional properties, to work around TS making them required
+// see https://github.com/krzkaczor/ts-essentials/issues/118
 export type DeepOmit<T extends DeepOmitModify<Filter>, Filter> = T extends Builtin
   ? T
   : T extends Map<infer KeyType, infer ValueType>
@@ -212,9 +214,8 @@ export type DeepOmit<T extends DeepOmitModify<Filter>, Filter> = T extends Built
   : T extends Promise<infer ItemType>
   ? ItemType extends DeepOmitModify<Filter>
     ? Promise<DeepOmit<ItemType, Filter>>
-    : T // explicitly mentioning optional properties, to work around TS making them required
-  : // see https://github.com/krzkaczor/ts-essentials/issues/118
-    { [K in Exclude<OptionalKeys<T>, keyof Filter>]+?: T[K] } &
+    : T
+  : { [K in Exclude<OptionalKeys<T>, keyof Filter>]+?: T[K] } &
       OmitProperties<
         {
           [K in Extract<OptionalKeys<T>, keyof Filter>]+?: Filter[K] extends true

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -170,10 +170,12 @@ export type OmitProperties<T, P> = Pick<T, { [K in keyof T]: T[K] extends P ? ne
 /** Pick all properties of given type in object type */
 export type PickProperties<T, P> = Pick<T, { [K in keyof T]: T[K] extends P ? K : never }[keyof T]>;
 
+/** Gets keys of an object which are optional */
 export type OptionalKeys<T> = {
   [K in keyof T]-?: undefined extends { [K2 in keyof T]: K2 }[K] ? K : never;
 }[keyof T];
 
+/** Gets keys of an object which are required */
 export type RequiredKeys<T> = Exclude<keyof T, OptionalKeys<T>>;
 
 /** Recursively omit deep properties */
@@ -211,9 +213,9 @@ export type DeepOmit<T extends DeepOmitModify<Filter>, Filter> = T extends Built
   ? ItemType extends DeepOmitModify<Filter>
     ? Promise<DeepOmit<ItemType, Filter>>
     : T
-  // explicitly mentioning optional properties, to work around TS making them required
-  // see https://github.com/krzkaczor/ts-essentials/issues/118
-  : { [K in Exclude<OptionalKeys<T>, keyof Filter>]+?: T[K] } &
+  : // explicitly mentioning optional properties, to work around TS making them required
+    // see https://github.com/krzkaczor/ts-essentials/issues/118
+    { [K in Exclude<OptionalKeys<T>, keyof Filter>]+?: T[K] } &
       OmitProperties<
         {
           [K in Extract<OptionalKeys<T>, keyof Filter>]+?: Filter[K] extends true

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -212,9 +212,8 @@ export type DeepOmit<T extends DeepOmitModify<Filter>, Filter> = T extends Built
   : T extends Promise<infer ItemType>
   ? ItemType extends DeepOmitModify<Filter>
     ? Promise<DeepOmit<ItemType, Filter>>
-    : T
-  : // explicitly mentioning optional properties, to work around TS making them required
-    // see https://github.com/krzkaczor/ts-essentials/issues/118
+    : T // explicitly mentioning optional properties, to work around TS making them required
+  : // see https://github.com/krzkaczor/ts-essentials/issues/118
     { [K in Exclude<OptionalKeys<T>, keyof Filter>]+?: T[K] } &
       OmitProperties<
         {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -171,7 +171,7 @@ export type OmitProperties<T, P> = Pick<T, { [K in keyof T]: T[K] extends P ? ne
 export type PickProperties<T, P> = Pick<T, { [K in keyof T]: T[K] extends P ? K : never }[keyof T]>;
 
 export type OptionalKeys<T> = {
-  [K in keyof T]-?: undefined extends { [K2 in keyof T]: K2 }[K] ? K : never
+  [K in keyof T]-?: undefined extends { [K2 in keyof T]: K2 }[K] ? K : never;
 }[keyof T];
 
 export type RequiredKeys<T> = Exclude<keyof T, OptionalKeys<T>>;
@@ -212,26 +212,27 @@ export type DeepOmit<T extends DeepOmitModify<Filter>, Filter> = T extends Built
     ? Promise<DeepOmit<ItemType, Filter>>
     : T
   : { [K in Exclude<OptionalKeys<T>, keyof Filter>]+?: T[K] } &
-  OmitProperties<
-    {
-      [K in Extract<OptionalKeys<T>, keyof Filter>]+?: Filter[K] extends true
-        ? never
-        : T[K] extends DeepOmitModify<Filter[K]>
-        ? DeepOmit<T[K], Filter[K]>
-        : T[K];
-    },
-    never
-  > & { [K in Exclude<RequiredKeys<T>, keyof Filter>]: T[K] } &
-  OmitProperties<
-    {
-      [K in Extract<RequiredKeys<T>, keyof Filter>]: Filter[K] extends true
-        ? never
-        : T[K] extends DeepOmitModify<Filter[K]>
-        ? DeepOmit<T[K], Filter[K]>
-        : T[K];
-    },
-    never
-  >;
+      OmitProperties<
+        {
+          [K in Extract<OptionalKeys<T>, keyof Filter>]+?: Filter[K] extends true
+            ? never
+            : T[K] extends DeepOmitModify<Filter[K]>
+            ? DeepOmit<T[K], Filter[K]>
+            : T[K];
+        },
+        never
+      > &
+      { [K in Exclude<RequiredKeys<T>, keyof Filter>]: T[K] } &
+      OmitProperties<
+        {
+          [K in Extract<RequiredKeys<T>, keyof Filter>]: Filter[K] extends true
+            ? never
+            : T[K] extends DeepOmitModify<Filter[K]>
+            ? DeepOmit<T[K], Filter[K]>
+            : T[K];
+        },
+        never
+      >;
 type DeepOmitModify<T> =
   | {
       [K in keyof T]: T[K] extends never ? any : T[K] extends object ? DeepOmitModify<T[K]> : never;

--- a/test/index.ts
+++ b/test/index.ts
@@ -32,6 +32,8 @@ import {
   Tail,
   Exact,
   ElementOf,
+  OptionalKeys,
+  RequiredKeys,
 } from "../lib";
 
 function testDictionary() {
@@ -256,6 +258,36 @@ function testPickProperties() {
   type Test2 = Assert<IsExact<PickProperties<{ a: string; b: number }, any[]>, {}>>;
 }
 
+function testOptionalKeys() {
+  type Input = {
+    req: string;
+    opt?: string;
+    opt2?: string;
+    undef: string | undefined;
+    nullable: string | null;
+  }
+
+  type Expected = 'opt' | 'opt2';
+  type Actual = OptionalKeys<Input>;
+
+  type Test = Assert<IsExact<Expected, Actual>>;
+}
+
+function testRequiredKeys() {
+  type Input = {
+    req: string;
+    opt?: string;
+    opt2?: string;
+    undef: string | undefined;
+    nullable: string | null;
+  }
+
+  type Expected = 'req' | 'undef' | 'nullable';
+  type Actual = RequiredKeys<Input>;
+
+  type Test = Assert<IsExact<Expected, Actual>>;
+}
+
 function testDeepOmit() {
   type Nested = {
     a: { b: string; c: { d: string; e: boolean }; f: number };
@@ -269,7 +301,6 @@ function testDeepOmit() {
       }
     >;
   };
-
   type Omitted = {
     a: { c: { e: boolean }; f: number };
     array: { b: boolean }[][];
@@ -285,6 +316,21 @@ function testDeepOmit() {
   };
 
   type Test = Assert<IsExact<DeepOmit<Nested, Filter>, Omitted>>;
+}
+
+function testDeepOmit2(){
+  type OptionalProperty = {
+    id: string;
+    age: number;
+    name?: string
+  }
+  type Omitted = {
+    id: string;
+    name?: string
+  }
+
+  type Result = DeepOmit<OptionalProperty, {age: never}>;
+  type Test = Assert<IsExact<Result, Omitted>>;
 }
 
 function testTupleInference() {

--- a/test/index.ts
+++ b/test/index.ts
@@ -265,9 +265,9 @@ function testOptionalKeys() {
     opt2?: string;
     undef: string | undefined;
     nullable: string | null;
-  }
+  };
 
-  type Expected = 'opt' | 'opt2';
+  type Expected = "opt" | "opt2";
   type Actual = OptionalKeys<Input>;
 
   type Test = Assert<IsExact<Expected, Actual>>;
@@ -280,9 +280,9 @@ function testRequiredKeys() {
     opt2?: string;
     undef: string | undefined;
     nullable: string | null;
-  }
+  };
 
-  type Expected = 'req' | 'undef' | 'nullable';
+  type Expected = "req" | "undef" | "nullable";
   type Actual = RequiredKeys<Input>;
 
   type Test = Assert<IsExact<Expected, Actual>>;
@@ -318,18 +318,18 @@ function testDeepOmit() {
   type Test = Assert<IsExact<DeepOmit<Nested, Filter>, Omitted>>;
 }
 
-function testDeepOmit2(){
+function testDeepOmit2() {
   type OptionalProperty = {
     id: string;
     age: number;
-    name?: string
-  }
+    name?: string;
+  };
   type Omitted = {
     id: string;
-    name?: string
-  }
+    name?: string;
+  };
 
-  type Result = DeepOmit<OptionalProperty, {age: never}>;
+  type Result = DeepOmit<OptionalProperty, { age: never }>;
   type Test = Assert<IsExact<Result, Omitted>>;
 }
 


### PR DESCRIPTION
While I feel this is a typescript bug in that the compiler loses attributes on the members of a type when member names are filtered, this probably should still get worked around in ts-essentials.

The resulting DeepOmit type is not exactly the same because the members are in a different order, but I am not sure how to possibly test member ordering within Typescript.

I also made RequiredKeys and OptionalKeys exported here because I have found good utility out of them in other projects. 