### PR TITLE
fix: allow readonly arrays in ElementOf

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -301,7 +301,7 @@ export type Opaque<Type, Token extends string> = Token extends StringLiteral<Tok
 export type ValueOf<T> = T[keyof T];
 
 /** Easily extract the type of a given array's elements */
-export type ElementOf<T extends any[]> = T extends (infer ET)[] ? ET : never;
+export type ElementOf<T extends readonly any[]> = T extends readonly (infer ET)[] ? ET : never;
 
 /** Type constraint for tuple inference */
 export type Tuple<T = any> = [T] | T[];

--- a/test/index.ts
+++ b/test/index.ts
@@ -571,7 +571,9 @@ function testExact() {
 
 function testElementOf() {
   const t1 = [1, 2, true, false];
-  type testElementOf = Assert<IsExact<ElementOf<typeof t1>, number | boolean>>;
+  type a1 = Assert<IsExact<ElementOf<typeof t1>, number | boolean>>;
+  const t2 = ["one"] as const;
+  type a2 = Assert<IsExact<ElementOf<typeof t2>, "one">>;
 }
 
 function testOpaque() {


### PR DESCRIPTION
`ElementOf` currently reject `readonly` arrays. Wee PR to add support for same.