### PR TITLE
DeepReadonly: Type 'unknown' is not assignable to type 'Readonly<unknown>'

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
 /** Essentials */
-export type Primitive = string | number | boolean | bigint | symbol | undefined | null | unknown;
+export type Primitive = string | number | boolean | bigint | symbol | undefined | null;
 export type Builtin = Primitive | Function | Date | Error | RegExp;
 export type IsTuple<T> = T extends [infer A]
   ? T
@@ -156,7 +156,9 @@ export type DeepReadonly<T> = T extends Builtin
   ? Promise<DeepReadonly<U>>
   : T extends {}
   ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
-  : Readonly<T>;
+  : // : T extends unknown
+    // ? unknown
+    Readonly<T>;
 
 /** Make readonly object writable */
 export type Writable<T> = { -readonly [P in keyof T]: T[P] };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
 /** Essentials */
-export type Primitive = string | number | boolean | bigint | symbol | undefined | null;
+export type Primitive = string | number | boolean | bigint | symbol | undefined | null | unknown;
 export type Builtin = Primitive | Function | Date | Error | RegExp;
 export type IsTuple<T> = T extends [infer A]
   ? T

--- a/test/index.ts
+++ b/test/index.ts
@@ -95,6 +95,7 @@ type ComplexNestedPartial = {
     >;
     promise?: Promise<{ foo?: string; bar?: number }>;
   };
+  unknown?: unknown;
 };
 
 type ComplexNestedRequired = {
@@ -113,6 +114,7 @@ type ComplexNestedRequired = {
     >;
     promise: Promise<{ foo: string; bar: number }>;
   };
+  unknown: unknown;
 };
 
 type ComplexNestedNullable = {
@@ -126,6 +128,7 @@ type ComplexNestedNullable = {
     map: Map<string | null, { name: string | null }>;
     promise: Promise<{ foo: string | null; bar: number | null }>;
   };
+  unknown: unknown | null;
 };
 
 type ComplexNestedUndefinable = {
@@ -139,6 +142,7 @@ type ComplexNestedUndefinable = {
     map: Map<string | undefined, { name: string | undefined }>;
     promise: Promise<{ foo: string | undefined; bar: number | undefined }>;
   };
+  unknown: unknown | undefined;
 };
 
 type ComplexNestedNullableOrUndefined = {
@@ -184,6 +188,7 @@ type ComplexNestedNullableOrUndefined = {
       | null
       | undefined;
   };
+  unknown: unknown | null | undefined;
 };
 
 type ComplexNestedReadonly = {
@@ -204,6 +209,7 @@ type ComplexNestedReadonly = {
     >;
     readonly promise: Promise<{ readonly foo: string; readonly bar: number }>;
   };
+  readonly unknown: unknown;
 };
 
 function testDeepPartial() {


### PR DESCRIPTION
```
type Test1 = {
	abc: unknown
}

const val: Test1 = { abc: '' }
const val2: DeepReadonly<Test1> = val
```
Gives the error:
```
error TS2322: Type 'Test1' is not assignable to type '{ readonly abc: Readonly<unknown>; }'.
  Types of property 'abc' are incompatible.
    Type 'unknown' is not assignable to type 'Readonly<unknown>'.
```

This lets it translate the type cleanly across

