### PR TITLE
Make build script cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf ./dist && tsc -p tsconfig.prod.json --outDir ./dist",
+    "build": "rimraf ./dist && tsc -p tsconfig.prod.json --outDir ./dist",
     "formatDeclarations": "prettier --ignore-path *.js --write dist/*.d.ts",
     "prepublishOnly": "yarn test && yarn build && yarn formatDeclarations",
     "test": "prettier -c **/*.ts && tsc --noEmit",
@@ -35,6 +35,7 @@
     "@codechecks/client": "^0.1.10",
     "conditional-type-checks": "^1.0.4",
     "prettier": "^1.19.1",
+    "rimraf": "^3.0.2",
     "typescript": "^3.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,6 +721,13 @@ request@^2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"


### PR DESCRIPTION
`rm -rf` is not cross-platform, please merge this to enable windows devs to work on this repo. The `&&`, though not windows-shell-compatible, is fine because yarn specifically makes it work.