### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+charset = utf-8
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adding a `.editorconfig` to your repo makes all the popular editors automatically respect some formatting rules regardless of personal settings to reduce first-time-setup friction for contributors. Indentation of 2 for example is not default with many people, making edits more tedious. Prettier does not help in this regard.

~The `end_of_line` may look contestable but no windows tool other than literally notepad.exe has issues with `lf`, and it removes any reliance on git's wonky auto-crlf (which in turn depends on careful git configuration) — uniformation beats configuration. This may work more nicely with an accompanying `.gitattributes` to force-disable git's autocrlf to prevent constant false change tracking on changed line-endings, but let's take 1 step at a time.~