### PR TITLE
Fix invalid sourcemap reference in published files

### DIFF
--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "inlineSourceMap": true,
+    "inlineSources": true
+  },
   "include": ["lib/**/*.ts"],
   "exclude": ["node_modules", "example"]
 }


### PR DESCRIPTION
Fixes #169 

I tried to set `inlineSources` first to simply change the invalid (unpublished) source file reference to an inline source and keep the whole sourcemap as a separate file, but ~despite what [the docs](https://www.typescriptlang.org/tsconfig#inlineSources) claim, this option didn't change the output,~ the same reference to `../lib` was still emitted.

Lacking a fix for that, the next step was to just inline it all into the js file.

PS: this PR is the reason for #187 and #188 