### PR TITLE
type: Improve Opaque

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -295,9 +295,11 @@ export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) ex
 
 type StringLiteral<T> = T extends string ? (string extends T ? never : T) : never;
 
+declare const __OPAQUE_TYPE__: unique symbol;
+
 /** Easily create opaque types ie. types that are subset of their original types (ex: positive numbers, uppercased string) */
 export type Opaque<Type, Token extends string> = Token extends StringLiteral<Token>
-  ? Type & { readonly __TYPE__: Token }
+  ? Type & { readonly [__OPAQUE_TYPE__]: Token }
   : never;
 
 /** Easily extract the type of a given object's values */

--- a/test/index.ts
+++ b/test/index.ts
@@ -595,9 +595,15 @@ function testElementOf() {
   type a2 = Assert<IsExact<ElementOf<typeof t2>, "one">>;
 }
 
+// T = U
+type Assignable<T, U> = U extends T ? true : false;
+
 function testOpaque() {
-  type t1 = Assert<IsExact<Opaque<number, "a">, number & { __TYPE__: "a" }>>;
-  type t2 = Assert<IsExact<Opaque<"a", string>, never>>; // should blow on mismatched order
+  type t1 = Assert<IsExact<Assignable<number, Opaque<number, "a">>, true>>;
+  type t2 = Assert<IsExact<Assignable<Opaque<number, "a">, number>, false>>;
+  type t3 = Assert<IsExact<Assignable<Opaque<number, "a">, Opaque<number, "b">>, false>>;
+  type t4 = Assert<IsExact<Assignable<Opaque<number, "a">, Opaque<number, "a">>, true>>;
+  type t5 = Assert<IsExact<Opaque<"a", string>, never>>; // should blow on mismatched order
 }
 
 function testAsyncOrSyncType() {


### PR DESCRIPTION
Based on the article I wrote – https://blog.beraliv.dev/2021-05-07-opaque-type-in-typescript/

- Symbol isn't accessible (in comparison to what was before)
- Symbol exists only in types
- Works since TypeScript 2.7 – https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#unique-symbol