### PR TITLE
test: 🧪 DeepUndefinable

### DIFF
--- a/.changeset/brave-lions-confess.md
+++ b/.changeset/brave-lions-confess.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Align `ReadonlySet` and `ReadonlyMap` in `DeepUndefinable` with other sets and maps

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -69,6 +69,8 @@ export type DeepUndefinable<T> = T extends Builtin
   ? T | undefined
   : T extends Map<infer K, infer V>
   ? Map<DeepUndefinable<K>, DeepUndefinable<V>>
+  : T extends ReadonlyMap<infer K, infer V>
+  ? ReadonlyMap<DeepUndefinable<K>, DeepUndefinable<V>>
   : T extends WeakMap<infer K, infer V>
   ? WeakMap<DeepUndefinable<K>, DeepUndefinable<V>>
   : T extends Set<infer U>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -75,6 +75,8 @@ export type DeepUndefinable<T> = T extends Builtin
   ? WeakMap<DeepUndefinable<K>, DeepUndefinable<V>>
   : T extends Set<infer U>
   ? Set<DeepUndefinable<U>>
+  : T extends ReadonlySet<infer U>
+  ? ReadonlySet<DeepUndefinable<U>>
   : T extends WeakSet<infer U>
   ? WeakSet<DeepUndefinable<U>>
   : T extends Array<infer U>

--- a/test/index.ts
+++ b/test/index.ts
@@ -364,45 +364,6 @@ function testNonNullable() {
   type Test = Assert<IsExact<NonNullable<"abc" | null | undefined>, "abc">>;
 }
 
-type SimpleType = {
-  field1: string;
-  field2: string;
-  field3: {
-    field4: string;
-    field5: number;
-    field6: {
-      field7: number;
-      field8: string;
-    };
-  };
-};
-
-type SimpleTypeNullable = {
-  field1: string | null;
-  field2: string | null;
-  field3: {
-    field4: string | null;
-    field5: number | null;
-    field6: {
-      field7: number | null;
-      field8: string | null;
-    };
-  };
-};
-
-type SimpleTypeUndefinable = {
-  field1: string | undefined;
-  field2: string | undefined;
-  field3: {
-    field4: string | undefined;
-    field5: number | undefined;
-    field6: {
-      field7: number | undefined;
-      field8: string | undefined;
-    };
-  };
-};
-
 function testDeepUndefinable() {
   type cases = [
     Assert<IsExact<DeepUndefinable<number>, number | undefined>>,
@@ -457,7 +418,6 @@ function testDeepUndefinable() {
     Assert<IsExact<DeepUndefinable<{ a: 1; b: 2; c: 3 }>, { a: 1 | undefined; b: 2 | undefined; c: 3 | undefined }>>,
     Assert<IsExact<DeepUndefinable<{ foo: () => void }>, { foo: (() => void) | undefined }>>,
     Assert<IsExact<DeepUndefinable<ComplexNestedRequired>, ComplexNestedUndefinable>>,
-    Assert<IsExact<DeepUndefinable<SimpleType>, SimpleTypeUndefinable>>,
   ];
 }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -362,9 +362,61 @@ function testDeepNullable2() {
 }
 
 function testDeepUndefinable() {
-  type Test1 = AssertFalse<IsExact<DeepUndefinable<SimpleType>, DeepPartial<SimpleType>>>;
-  type Test2 = Assert<IsExact<DeepUndefinable<SimpleType>, SimpleTypeUndefinable>>;
-  type Test3 = Assert<IsExact<DeepUndefinable<ComplexNestedRequired>, ComplexNestedUndefinable>>;
+  type cases = [
+    Assert<IsExact<DeepUndefinable<number>, number | undefined>>,
+    Assert<IsExact<DeepUndefinable<string>, string | undefined>>,
+    Assert<IsExact<DeepUndefinable<boolean>, boolean | undefined>>,
+    Assert<IsExact<DeepUndefinable<bigint>, bigint | undefined>>,
+    Assert<IsExact<DeepUndefinable<symbol>, symbol | undefined>>,
+    Assert<IsExact<DeepUndefinable<undefined>, undefined>>,
+    Assert<IsExact<DeepUndefinable<null>, null | undefined>>,
+    Assert<IsExact<DeepUndefinable<Function>, Function | undefined>>,
+    Assert<IsExact<DeepUndefinable<Date>, Date | undefined>>,
+    Assert<IsExact<DeepUndefinable<Error>, Error | undefined>>,
+    Assert<IsExact<DeepUndefinable<RegExp>, RegExp | undefined>>,
+    Assert<IsExact<DeepUndefinable<Map<string, boolean>>, Map<string | undefined, boolean | undefined>>>,
+    Assert<IsExact<DeepUndefinable<Map<string, { a: number }>>, Map<string | undefined, { a: number | undefined }>>>,
+    Assert<
+      IsExact<DeepUndefinable<ReadonlyMap<string, boolean>>, ReadonlyMap<string | undefined, boolean | undefined>>
+    >,
+    Assert<
+      IsExact<
+        DeepUndefinable<ReadonlyMap<string, { checked: boolean }>>,
+        ReadonlyMap<string | undefined, { checked: boolean | undefined }>
+      >
+    >,
+    Assert<
+      IsExact<
+        DeepUndefinable<WeakMap<{ key: string }, boolean>>,
+        WeakMap<{ key: string | undefined }, boolean | undefined>
+      >
+    >,
+    Assert<
+      IsExact<
+        DeepUndefinable<WeakMap<{ key: string }, { value: boolean }>>,
+        WeakMap<{ key: string | undefined }, { value: boolean | undefined }>
+      >
+    >,
+    Assert<IsExact<DeepUndefinable<Set<string>>, Set<string | undefined>>>,
+    Assert<IsExact<DeepUndefinable<Set<number[]>>, Set<(number | undefined)[]>>>,
+    Assert<IsExact<DeepUndefinable<ReadonlySet<string>>, ReadonlySet<string | undefined>>>,
+    Assert<IsExact<DeepUndefinable<[]>, []>>,
+    Assert<IsExact<DeepUndefinable<never[]>, undefined[]>>,
+    Assert<IsExact<DeepUndefinable<[1, 2, 3]>, [1 | undefined, 2 | undefined, 3 | undefined]>>,
+    Assert<IsExact<DeepUndefinable<readonly number[]>, readonly (number | undefined)[]>>,
+    Assert<IsExact<DeepUndefinable<Array<number>>, Array<number | undefined>>>,
+    Assert<IsExact<DeepUndefinable<Promise<number>>, Promise<number | undefined>>>,
+    Assert<
+      IsExact<
+        DeepUndefinable<Promise<{ api: () => { play: () => void; pause: () => void } }>>,
+        Promise<{ api: (() => { play: () => void; pause: () => void }) | undefined }>
+      >
+    >,
+    Assert<IsExact<DeepUndefinable<{ a: 1; b: 2; c: 3 }>, { a: 1 | undefined; b: 2 | undefined; c: 3 | undefined }>>,
+    Assert<IsExact<DeepUndefinable<{ foo: () => void }>, { foo: (() => void) | undefined }>>,
+    Assert<IsExact<DeepUndefinable<ComplexNestedRequired>, ComplexNestedUndefinable>>,
+    Assert<IsExact<DeepUndefinable<SimpleType>, SimpleTypeUndefinable>>,
+  ];
 }
 
 function testDeepNonNullable() {


### PR DESCRIPTION
Fixed `DeepUndefinable` for `ReadonlySet` and `ReadonlyMap`