### PR TITLE
fix: 🧪 DeepRequire

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -541,71 +541,94 @@ function testDeepNonNullable() {
 
 function testDeepRequire() {
   type cases = [
-    Assert<IsExact<DeepRequired<number | null | undefined>, number>>,
-    Assert<IsExact<DeepRequired<string | null | undefined>, string>>,
-    Assert<IsExact<DeepRequired<boolean | null | undefined>, boolean>>,
-    Assert<IsExact<DeepRequired<bigint | null | undefined>, bigint>>,
-    Assert<IsExact<DeepRequired<symbol | null | undefined>, symbol>>,
-    Assert<IsExact<DeepRequired<undefined | null>, never>>,
-    Assert<IsExact<DeepRequired<Function | null | undefined>, Function>>,
-    Assert<IsExact<DeepRequired<Date | null | undefined>, Date>>,
-    Assert<IsExact<DeepRequired<Error | null | undefined>, Error>>,
-    Assert<IsExact<DeepRequired<RegExp | null | undefined>, RegExp>>,
-    Assert<IsExact<DeepRequired<Map<string | null | undefined, boolean | null | undefined>>, Map<string, boolean>>>,
+    Assert<IsExact<DeepRequired<number | null | undefined>, number | null | undefined>>,
+    Assert<IsExact<DeepRequired<string | null | undefined>, string | null | undefined>>,
+    Assert<IsExact<DeepRequired<boolean | null | undefined>, boolean | null | undefined>>,
+    Assert<IsExact<DeepRequired<bigint | null | undefined>, bigint | null | undefined>>,
+    Assert<IsExact<DeepRequired<symbol | null | undefined>, symbol | null | undefined>>,
+    Assert<IsExact<DeepRequired<undefined | null>, undefined | null>>,
+    Assert<IsExact<DeepRequired<Function | null | undefined>, Function | null | undefined>>,
+    Assert<IsExact<DeepRequired<Date | null | undefined>, Date | null | undefined>>,
+    Assert<IsExact<DeepRequired<Error | null | undefined>, Required<Error> | null | undefined>>,
+    Assert<IsExact<DeepRequired<RegExp | null | undefined>, RegExp | null | undefined>>,
+    Assert<
+      IsExact<
+        DeepRequired<Map<string | null | undefined, boolean | null | undefined>>,
+        Map<string | null | undefined, boolean | null | undefined>
+      >
+    >,
     Assert<
       IsExact<
         DeepRequired<Map<string | null | undefined, { a: number | null | undefined }>>,
-        Map<string, { a: number }>
+        Map<string | null | undefined, { a: number | null | undefined }>
       >
     >,
     Assert<
       IsExact<
         DeepRequired<ReadonlyMap<string | null | undefined, boolean | null | undefined>>,
-        ReadonlyMap<string, boolean>
+        ReadonlyMap<string | null | undefined, boolean | null | undefined>
       >
     >,
     Assert<
       IsExact<
         DeepRequired<ReadonlyMap<string | null | undefined, { checked: boolean | null | undefined }>>,
-        ReadonlyMap<string, { checked: boolean }>
+        ReadonlyMap<string | null | undefined, { checked: boolean | null | undefined }>
       >
     >,
     Assert<
       IsExact<
         DeepRequired<WeakMap<{ key: string | null | undefined }, boolean | null | undefined>>,
-        WeakMap<{ key: string }, boolean>
+        WeakMap<{ key: string | null | undefined }, boolean | null | undefined>
       >
     >,
     Assert<
       IsExact<
         DeepRequired<WeakMap<{ key: string | null | undefined }, { value: boolean | null | undefined }>>,
-        WeakMap<{ key: string }, { value: boolean }>
+        WeakMap<{ key: string | null | undefined }, { value: boolean | null | undefined }>
       >
     >,
-    Assert<IsExact<DeepRequired<Set<string | null | undefined>>, Set<string>>>,
-    Assert<IsExact<DeepRequired<Set<(number | null | undefined)[]>>, Set<number[]>>>,
-    Assert<IsExact<DeepRequired<ReadonlySet<string | null | undefined>>, ReadonlySet<string>>>,
-    Assert<IsExact<DeepRequired<[] | null | undefined>, []>>,
-    Assert<IsExact<DeepRequired<(null | undefined)[]>, never[]>>,
-    Assert<IsExact<DeepRequired<[1 | null | undefined, 2 | null | undefined, 3 | null | undefined]>, [1, 2, 3]>>,
-    Assert<IsExact<DeepRequired<readonly (number | null | undefined)[]>, readonly number[]>>,
-    Assert<IsExact<DeepRequired<Array<number | null | undefined>>, Array<number>>>,
-    Assert<IsExact<DeepRequired<Promise<number | null | undefined>>, Promise<number>>>,
+    Assert<IsExact<DeepRequired<Set<string | null | undefined>>, Set<string | null | undefined>>>,
+    Assert<IsExact<DeepRequired<Set<(number | null | undefined)[]>>, Set<(number | null)[]>>>,
+    Assert<IsExact<DeepRequired<ReadonlySet<string | null | undefined>>, ReadonlySet<string | null | undefined>>>,
+    Assert<IsExact<DeepRequired<[] | null | undefined>, [] | null | undefined>>,
+    Assert<IsExact<DeepRequired<(null | undefined)[]>, null[]>>,
+    Assert<
+      IsExact<
+        DeepRequired<[1 | null | undefined, 2 | null | undefined, 3 | null | undefined]>,
+        [1 | null | undefined, 2 | null | undefined, 3 | null | undefined]
+      >
+    >,
+    Assert<
+      IsExact<
+        DeepRequired<[(1 | null | undefined)?, (2 | null | undefined)?, (3 | null | undefined)?]>,
+        [1 | null, 2 | null, 3 | null]
+      >
+    >,
+    Assert<IsExact<DeepRequired<readonly (number | null | undefined)[]>, readonly (number | null)[]>>,
+    Assert<IsExact<DeepRequired<Array<number | null | undefined>>, Array<number | null>>>,
+    Assert<IsExact<DeepRequired<Promise<number | null | undefined>>, Promise<number | null | undefined>>>,
     Assert<
       IsExact<
         DeepRequired<Promise<{ api: (() => { play: () => void; pause: () => void }) | null | undefined }>>,
-        Promise<{ api: () => { play: () => void; pause: () => void } }>
+        Promise<{
+          api:
+            | (() => {
+                play: () => void;
+                pause: () => void;
+              })
+            | null
+            | undefined;
+        }>
       >
     >,
     Assert<
       IsExact<
         DeepRequired<{ a: 1 | null | undefined; b: 2 | null | undefined; c: 3 | null | undefined }>,
-        { a: 1; b: 2; c: 3 }
+        { a: 1 | null | undefined; b: 2 | null | undefined; c: 3 | null | undefined }
       >
     >,
-    Assert<IsExact<DeepRequired<{ foo: (() => void) | null | undefined }>, { foo: () => void }>>,
+    Assert<IsExact<DeepRequired<{ foo: (() => void) | null | undefined }>, { foo: (() => void) | null | undefined }>>,
     Assert<IsExact<DeepRequired<{ a?: 1; b?: 2 }>, { a: 1; b: 2 }>>,
-    Assert<IsExact<DeepRequired<ComplexNestedNullableOrUndefined>, ComplexNestedRequired>>,
     Assert<IsExact<DeepRequired<ComplexNestedPartial>, ComplexNestedRequired>>,
   ];
 }


### PR DESCRIPTION
Make `DeepRequire` as recursive `Require` without removing `null` and `undefined` unexpectedly

For removing `null` and `undefined` `DeepNonNullable` can be used