### PR TITLE
fix: 🧪 DeepPartial for unknown

### DIFF
--- a/.changeset/bright-penguins-tap.md
+++ b/.changeset/bright-penguins-tap.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Fix `DeepPartial` and `Buildable` for `unknown`

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -44,6 +44,8 @@ export type DeepPartial<T> = T extends Builtin
   ? Promise<DeepPartial<U>>
   : T extends {}
   ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : IsUnknown<T> extends true
+  ? unknown
   : Partial<T>;
 
 /** Recursive nullable */
@@ -159,7 +161,7 @@ export type DeepReadonly<T> = T extends Builtin
   ? Promise<DeepReadonly<U>>
   : T extends {}
   ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
-  : unknown extends T
+  : IsUnknown<T> extends true
   ? unknown
   : Readonly<T>;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,9 @@
 export type Primitive = string | number | boolean | bigint | symbol | undefined | null;
 export type Builtin = Primitive | Function | Date | Error | RegExp;
 export type IsTuple<T> = T extends any[] ? (any[] extends T ? never : T) : never;
+// https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type IsUnknown<T> = IsAny<T> extends true ? false : unknown extends T ? true : false;
 export type AnyArray<T = any> = Array<T> | ReadonlyArray<T>;
 
 /**

--- a/test/index.ts
+++ b/test/index.ts
@@ -298,8 +298,8 @@ function testDeepPartial() {
       IsExact<
         DeepPartial<{ readonly obj: unknown; readonly arr: readonly unknown[] }>,
         {
-          obj?: unknown | undefined;
-          arr?: unknown[] | undefined;
+          readonly obj?: unknown | undefined;
+          readonly arr?: readonly unknown[] | undefined;
         }
       >
     >,

--- a/test/index.ts
+++ b/test/index.ts
@@ -294,6 +294,15 @@ function testDeepPartial() {
         Promise<{ api?: () => { play: () => void; pause: () => void } }>
       >
     >,
+    Assert<
+      IsExact<
+        DeepPartial<{ readonly obj: unknown; readonly arr: readonly unknown[] }>,
+        {
+          obj?: unknown | undefined;
+          arr?: unknown[] | undefined;
+        }
+      >
+    >,
     Assert<IsExact<DeepPartial<{ a: 1; b: 2; c: 3 }>, { a?: 1; b?: 2; c?: 3 }>>,
     Assert<IsExact<DeepPartial<{ foo: () => void }>, { foo?: () => void }>>,
     Assert<IsExact<DeepPartial<ComplexNestedRequired>, ComplexNestedPartial>>,
@@ -740,8 +749,8 @@ function testBuildable() {
       IsExact<
         Buildable<{ readonly obj: unknown; readonly arr: readonly unknown[] }>,
         {
-          obj?: Partial<unknown> | undefined;
-          arr?: Partial<unknown>[] | undefined;
+          obj?: unknown | undefined;
+          arr?: unknown[] | undefined;
         }
       >
     >,


### PR DESCRIPTION
Fix `DeepPartial` and `Buildable` for `unknown`