### PR TITLE
fix: 🧪 StrictOmit

### DIFF
--- a/.changeset/long-bears-fetch.md
+++ b/.changeset/long-bears-fetch.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Allow objects to be used in `StrictOmit`

--- a/.changeset/long-bears-fetch.md
+++ b/.changeset/long-bears-fetch.md
@@ -2,4 +2,4 @@
 "ts-essentials": patch
 ---
 
-Allow objects to be used in `StrictOmit`
+Allow only objects to be used in `StrictOmit`

--- a/.changeset/warm-experts-cheat.md
+++ b/.changeset/warm-experts-cheat.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+`StrictOmit` returns `never` for arrays and tuples

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -188,7 +188,7 @@ export type DeepWritable<T> = T extends Builtin
 export type Buildable<T> = DeepPartial<DeepWritable<T>>;
 
 /** Similar to the builtin Omit, but checks the filter strictly. */
-export type StrictOmit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type StrictOmit<T, K extends keyof T> = Omit<T, K>;
 
 /** Similar to the builtin Extract, but checks the filter strictly */
 export type StrictExtract<T, U extends Partial<T>> = Extract<T, U>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,7 @@
 export type Primitive = string | number | boolean | bigint | symbol | undefined | null;
 export type Builtin = Primitive | Function | Date | Error | RegExp;
 export type IsTuple<T> = T extends any[] ? (any[] extends T ? never : T) : never;
+type AnyRecord<T = any> = Record<PropertyKey, T>;
 export type AnyArray<T = any> = Array<T> | ReadonlyArray<T>;
 
 /**
@@ -188,7 +189,7 @@ export type DeepWritable<T> = T extends Builtin
 export type Buildable<T> = DeepPartial<DeepWritable<T>>;
 
 /** Similar to the builtin Omit, but checks the filter strictly. */
-export type StrictOmit<T, K extends keyof T> = Omit<T, K>;
+export type StrictOmit<T extends AnyRecord, K extends keyof T> = T extends AnyArray ? never : Omit<T, K>;
 
 /** Similar to the builtin Extract, but checks the filter strictly */
 export type StrictExtract<T, U extends Partial<T>> = Extract<T, U>;

--- a/test/index.ts
+++ b/test/index.ts
@@ -44,6 +44,7 @@ import {
   PickKeys,
   IsTuple,
   Writable,
+  StrictOmit,
 } from "../lib";
 
 function testDictionary() {
@@ -748,6 +749,17 @@ function testBuildable() {
     Assert<IsExact<Buildable<DeepReadonly<ComplexNestedRequired>>, ComplexNestedPartial>>,
     Assert<IsExact<Buildable<ComplexNestedRequired>, ComplexNestedPartial>>,
     Assert<IsExact<Buildable<ComplexNestedReadonly>, ComplexNestedPartial>>,
+  ];
+}
+
+function testStrictOmit() {
+  type cases = [
+    Assert<IsExact<StrictOmit<{}, never>, {}>>,
+    Assert<IsExact<StrictOmit<{ a: 1 }, never>, { a: 1 }>>,
+    Assert<IsExact<StrictOmit<{ a?: 1 }, never>, { a?: 1 }>>,
+    Assert<IsExact<StrictOmit<{ a: 1 }, "a">, {}>>,
+    Assert<IsExact<StrictOmit<{ a?: 1 }, "a">, {}>>,
+    Assert<IsExact<StrictOmit<{ a?: 1 }, "a">, {}>>,
   ];
 }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -754,12 +754,42 @@ function testBuildable() {
 
 function testStrictOmit() {
   type cases = [
+    // @ts-expect-error works only with records
+    StrictOmit<number, never>,
+    // @ts-expect-error works only with records
+    StrictOmit<string, never>,
+    // @ts-expect-error works only with records
+    StrictOmit<boolean, never>,
+    // @ts-expect-error works only with records
+    StrictOmit<bigint, never>,
+    // @ts-expect-error works only with records
+    StrictOmit<symbol, never>,
+    // @ts-expect-error works only with records
+    StrictOmit<undefined, never>,
+    // @ts-expect-error works only with records
+    StrictOmit<null, never>,
+    Assert<IsExact<StrictOmit<Function, never>, Function>>,
+    Assert<IsExact<StrictOmit<Date, never>, Date>>,
+    Assert<IsExact<StrictOmit<Error, never>, Error>>,
+    Assert<IsExact<StrictOmit<RegExp, never>, RegExp>>,
+    Assert<IsExact<StrictOmit<Map<string, boolean>, never>, Map<string, boolean>>>,
+    Assert<IsExact<StrictOmit<ReadonlyMap<string, boolean>, never>, ReadonlyMap<string, boolean>>>,
+    Assert<IsExact<StrictOmit<WeakMap<{ key: string }, boolean>, never>, WeakMap<{ key: string }, boolean>>>,
+    Assert<IsExact<StrictOmit<Set<string>, never>, Set<string>>>,
+    Assert<IsExact<StrictOmit<ReadonlySet<string>, never>, ReadonlySet<string>>>,
+    Assert<IsExact<StrictOmit<Promise<number>, never>, Promise<number>>>,
     Assert<IsExact<StrictOmit<{}, never>, {}>>,
     Assert<IsExact<StrictOmit<{ a: 1 }, never>, { a: 1 }>>,
     Assert<IsExact<StrictOmit<{ a?: 1 }, never>, { a?: 1 }>>,
     Assert<IsExact<StrictOmit<{ a: 1 }, "a">, {}>>,
     Assert<IsExact<StrictOmit<{ a?: 1 }, "a">, {}>>,
     Assert<IsExact<StrictOmit<{ a?: 1 }, "a">, {}>>,
+    // we don't prohibit arrays and tuples, but return never for them
+    Assert<IsExact<StrictOmit<readonly [], never>, never>>,
+    Assert<IsExact<StrictOmit<readonly [1, 2, 3], never>, never>>,
+    Assert<IsExact<StrictOmit<readonly number[], never>, never>>,
+    Assert<IsExact<StrictOmit<Array<number>, never>, never>>,
+    Assert<IsExact<StrictOmit<ReadonlyArray<number>, never>, never>>,
   ];
 }
 


### PR DESCRIPTION
1. Allow only objects to be used in `StrictOmit`
2. `StrictOmit` returns `never` for arrays and tuples