### PR TITLE
suggestion: 🚀 isExact approach 2

### DIFF
--- a/lib/functions.ts
+++ b/lib/functions.ts
@@ -14,6 +14,6 @@ export function assert(condition: any, msg: string = "no additional info provide
 
 export function noop(..._args: unknown[]): void {}
 
-export const isExact = <U>() => <T>(object: Exact<T, U>) => {
-  return object;
+export const isExact = <U>() => <T>(x: Exact<T, U>) => {
+  return x;
 };

--- a/lib/functions.ts
+++ b/lib/functions.ts
@@ -14,6 +14,6 @@ export function assert(condition: any, msg: string = "no additional info provide
 
 export function noop(..._args: unknown[]): void {}
 
-export const isExact = <U>() => <T>(x: Exact<T, U>) => {
+export const isExact = <ExpectedShape>() => <ActualShape>(x: Exact<ActualShape, ExpectedShape>): ExpectedShape => {
   return x;
 };

--- a/lib/functions.ts
+++ b/lib/functions.ts
@@ -14,6 +14,6 @@ export function assert(condition: any, msg: string = "no additional info provide
 
 export function noop(..._args: unknown[]): void {}
 
-export function isExact<T, EXACT_SHAPE>(x: Exact<T, EXACT_SHAPE>): EXACT_SHAPE {
-  return x;
-}
+export const isExact = <U>() => <T>(object: Exact<T, U>) => {
+  return object;
+};

--- a/test/index.ts
+++ b/test/index.ts
@@ -1209,19 +1209,30 @@ function testIsExact() {
   type BC2 = { b: number; c: string };
   type C = { c: number };
 
-  const abc: ABC = { a: 1, b: 2, c: 3 };
-  const bc: BC = { b: 2, c: 3 };
-  const bc2: BC2 = { b: 2, c: "3" };
-  const c: C = { c: 3 };
+  let abc: ABC = { a: 1, b: 2, c: 3 };
+  let abc2 = { a: 1, b: 2, c: 3 } as const;
+  let bc: BC = { b: 2, c: 3 };
+  let bc2: BC2 = { b: 2, c: "3" };
+  let bc3 = { b: 2, c: 3 } as const;
+  let bc4 = { b: 2, c: "3" } as const;
+  let c: C = { c: 3 };
+  let c2 = { c: 3 } as const;
 
   // @ts-expect-error ABC is not exactly BC (excessive property A)
   isExact<typeof abc, BC>(abc);
+  // @ts-expect-error ABC is not exactly BC (excessive property A)
+  isExact<typeof abc2, BC>(abc2);
 
   // BC is exactly BC
   isExact<typeof bc, BC>(bc);
   // @ts-expect-error BC2 is not exactly BC (C has different type)
   isExact<typeof bc2, BC>(bc2);
+  isExact<typeof bc3, BC>(bc3);
+  // @ts-expect-error C has different type (string literal instead of number)
+  isExact<typeof bc4, BC>(bc4);
 
   // @ts-expect-error C is not exactly BC (missing property B)
   isExact<typeof c, BC>(c);
+  // @ts-expect-error missing property B
+  isExact<typeof c, BC>(c2);
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -1219,21 +1219,21 @@ function testIsExact() {
   let c2 = { c: 3 } as const;
 
   // @ts-expect-error has different structure from BC (excessive property a)
-  isExact<typeof abc, BC>(abc);
+  isExact<BC>()(abc);
   // @ts-expect-error has different structure from BC (excessive property a)
-  isExact<typeof abc2, BC>(abc2);
+  isExact<BC>()(abc2);
 
   // has the same structure as BC
-  isExact<typeof bc, BC>(bc);
+  isExact<BC>()(bc);
   // @ts-expect-error has different structure from BC (c has different type)
-  isExact<typeof bc2, BC>(bc2);
+  isExact<BC>()(bc2);
   // has the same structure as BC
-  isExact<typeof bc3, BC>(bc3);
+  isExact<BC>()(bc3);
   // @ts-expect-error has different structure from BC (c has different type)
-  isExact<typeof bc4, BC>(bc4);
+  isExact<BC>()(bc4);
 
   // @ts-expect-error has different structure from BC (missing property b)
-  isExact<typeof c, BC>(c);
+  isExact<BC>()(c);
   // @ts-expect-error has different structure from BC (missing property b)
-  isExact<typeof c, BC>(c2);
+  isExact<BC>()(c2);
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -1218,21 +1218,22 @@ function testIsExact() {
   let c: C = { c: 3 };
   let c2 = { c: 3 } as const;
 
-  // @ts-expect-error ABC is not exactly BC (excessive property A)
+  // @ts-expect-error has different structure from BC (excessive property a)
   isExact<typeof abc, BC>(abc);
-  // @ts-expect-error ABC is not exactly BC (excessive property A)
+  // @ts-expect-error has different structure from BC (excessive property a)
   isExact<typeof abc2, BC>(abc2);
 
-  // BC is exactly BC
+  // has the same structure as BC
   isExact<typeof bc, BC>(bc);
-  // @ts-expect-error BC2 is not exactly BC (C has different type)
+  // @ts-expect-error has different structure from BC (c has different type)
   isExact<typeof bc2, BC>(bc2);
+  // has the same structure as BC
   isExact<typeof bc3, BC>(bc3);
-  // @ts-expect-error C has different type (string literal instead of number)
+  // @ts-expect-error has different structure from BC (c has different type)
   isExact<typeof bc4, BC>(bc4);
 
-  // @ts-expect-error C is not exactly BC (missing property B)
+  // @ts-expect-error has different structure from BC (missing property b)
   isExact<typeof c, BC>(c);
-  // @ts-expect-error missing property B
+  // @ts-expect-error has different structure from BC (missing property b)
   isExact<typeof c, BC>(c2);
 }


### PR DESCRIPTION
```ts
// the implementation
export const isExact = <U>() => <T>(object: Exact<T, U>) => {
  return object;
};

// the usage
isExact<BC>()(abc);

// or possible to reuse it later (which looks nicer)
const isBC = isExact<BC>();
isBC(abc);
```

I know extra `()` is kind of annoying, but imho less annoying than `typeof obj`