### PR TITLE
fix: 🧪 Use TypeScript@^4.1.0 because of introduced recursive conditional types

### DIFF
--- a/.changeset/good-knives-jam.md
+++ b/.changeset/good-knives-jam.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Use TypeScript@^4.1.0 because of introduced recursive conditional types

--- a/.changeset/strong-pillows-tease.md
+++ b/.changeset/strong-pillows-tease.md
@@ -1,5 +1,5 @@
 ---
-"ts-essentials": patch
+"ts-essentials": major
 ---
 
 Use TypeScript@^4.1.0 because of introduced recursive conditional types

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 npm install --save-dev ts-essentials
 ```
 
-👉 We require `typescript>=4.0`. If you're looking for support for older TS versions, please have a look at the
+👉 We require `typescript>=4.1`. If you're looking for support for older TS versions, please have a look at the
 [TypeScript dependency table](https://github.com/krzkaczor/ts-essentials/tree/master#TypeScript-dependency-table)
 
 👉 As we really want types to be stricter, we require enabled
@@ -944,7 +944,7 @@ type FirstParameter<FnT extends (...args: any) => any> = FnT extends (...args: i
 
 | `ts-essentials` | `typescript` / type of dependency |
 | --------------- | --------------------------------- |
-| `^8.0.0`        | `^4.0.0` / peer                   |
+| `^8.0.0`        | `^4.1.0` / peer                   |
 | `^5.0.0`        | `^3.7.0` / peer                   |
 | `^3.0.1`        | `^3.5.0` / peer                   |
 | `^1.0.1`        | `^3.2.2` / dev                    |

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "typescript": ">=4.0.0"
+    "typescript": ">=4.1.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.11.2",


### PR DESCRIPTION
Related to #257