### PR TITLE
feat: Add DeepReadonlyOptions to DeepReadonly

### DIFF
--- a/.changeset/thin-beans-lick.md
+++ b/.changeset/thin-beans-lick.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": minor
+---
+
+Add `OverrideDeepReadonlyOptions` to `DeepReadonly<Type, OverrideDeepReadonlyOptions?>` to allow configuring passthrough behaviour for built-in types (`Date`, `Error`, `RegExp`) per use-case

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ npm install --save-dev ts-essentials
 - [`DeepPick<Type, Filter>`](/lib/deep-pick) - Constructs a type by picking set of properties, which have property
   values `never` or `true` in type `Filter`, from type `Type`. If you'd like type `Filter` to be validated against a
   structure of `Type`, please use [`StrictDeepPick<Type, Filter>`](./lib/strict-deep-pick/).
-- [`DeepReadonly<Type>`](/lib/deep-readonly) - Constructs a type by picking all properties from type `Type` recursively
+- [`DeepReadonly<Type, OverrideDeepReadonlyOptions?>`](/lib/deep-readonly) - Constructs a type by picking all properties from type `Type` recursively
   and setting `readonly` modifier, meaning they cannot be reassigned. To make properties `readonly` on one level, use
   [`Readonly<Type>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype)
 - [`DeepRequired<Type>`](/lib/deep-required) - Constructs a type by picking all properties from type `Type` recursively

--- a/lib/deep-readonly/README.md
+++ b/lib/deep-readonly/README.md
@@ -45,3 +45,24 @@ function deepFreeze<Type extends object>(obj: Type): DeepReadonly<Type> {
 ```
 
 TS Playground – https://tsplay.dev/w6x5Em
+
+## Configuration
+
+There are 3 configurable built-in options under `builtin`: `error`, `date`, and `regexp`.
+
+When `false`, the type is treated as a passthrough (returned unchanged). When `true`, it is processed recursively like a plain object.
+
+| Option | Default |
+|--------|---------|
+| `builtin.date` | `false` |
+| `builtin.error` | `true` |
+| `builtin.regexp` | `false` |
+
+Example — make `RegExp` deeply readonly to satisfy `@typescript-eslint/prefer-readonly-parameter-types`:
+
+```ts
+type CustomDeepReadonly<Type> = DeepReadonly<Type, { builtin: { regexp: true; } }>;
+
+type ReadonlyRegExp = CustomDeepReadonly<RegExp>;
+//   ^? Readonly<RegExp> - lastIndex is now readonly
+```

--- a/lib/deep-readonly/index.test.ts
+++ b/lib/deep-readonly/index.test.ts
@@ -1,5 +1,5 @@
 import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
-import { DeepReadonly } from "..";
+import { DeepReadonly, ReadonlyKeys } from "..";
 import { ComplexNestedReadonly, ComplexNestedRequired } from "../test-types";
 
 function testDeepReadonly() {
@@ -29,11 +29,8 @@ function testDeepReadonly() {
     Assert<IsExact<DeepReadonly<null>, null>>,
     Assert<IsExact<DeepReadonly<Function>, Function>>,
     Assert<IsExact<DeepReadonly<ExtendedFunction>, ExtendedFunction>>,
-    Assert<IsExact<DeepReadonly<Date>, Date>>,
     Assert<IsExact<DeepReadonly<ExtendedDate>, ExtendedDate>>,
-    Assert<IsExact<DeepReadonly<Error>, Error>>,
     Assert<IsExact<DeepReadonly<ExtendedError>, Readonly<Error> & { readonly code: string }>>,
-    Assert<IsExact<DeepReadonly<RegExp>, RegExp>>,
     Assert<IsExact<DeepReadonly<ExtendedRegExp>, ExtendedRegExp>>,
     Assert<IsExact<DeepReadonly<Map<string, boolean>>, ReadonlyMap<string, boolean>>>,
     Assert<IsExact<DeepReadonly<ReadonlyMap<string, boolean>>, ReadonlyMap<string, boolean>>>,
@@ -108,6 +105,19 @@ function testDeepReadonly() {
 
     const readonlyObj2: DeepReadonly<TestObject> = obj;
   }
+}
+
+function testDeepReadonlyOptions() {
+  type cases = [
+    // default values
+    Assert<IsExact<ReadonlyKeys<DeepReadonly<Date>>, ReadonlyKeys<Date>>>,
+    Assert<IsExact<ReadonlyKeys<DeepReadonly<Error>>, keyof Error>>,
+    Assert<IsExact<ReadonlyKeys<DeepReadonly<RegExp>>, ReadonlyKeys<RegExp>>>,
+    // override values
+    Assert<IsExact<ReadonlyKeys<DeepReadonly<Date, { builtin: { date: true } }>>, keyof Date>>,
+    Assert<IsExact<ReadonlyKeys<DeepReadonly<Error, { builtin: { error: false } }>>, ReadonlyKeys<Error>>>,
+    Assert<IsExact<ReadonlyKeys<DeepReadonly<RegExp, { builtin: { regexp: true } }>>, keyof RegExp>>,
+  ];
 }
 
 function testDeepReadonlyForIterator() {

--- a/lib/deep-readonly/index.ts
+++ b/lib/deep-readonly/index.ts
@@ -1,39 +1,84 @@
 import { AnyArray } from "../any-array";
-import { Builtin } from "../built-in";
+import { CreateTypeOptions } from "../create-type-options";
 import { IsNever } from "../is-never";
 import { IsTuple } from "../is-tuple";
 import { IsUnknown } from "../is-unknown";
+import { Primitive } from "../primitive";
 
-type DeepReadonlyObject<Type> = {
-  readonly [Key in keyof Type]: Key extends typeof Symbol.iterator
-    ? Type[Key] extends () => Iterator<infer IteratorType, infer Return, infer Next>
-      ? () => Iterator<DeepReadonly<IteratorType>, DeepReadonly<Return>, DeepReadonly<Next>>
-      : DeepReadonly<Type[Key]>
-    : DeepReadonly<Type[Key]>;
+type DefaultDeepReadonlyOptions = {
+  builtin: {
+    date: false;
+    error: true;
+    regexp: false;
+  };
 };
 
-export type DeepReadonly<Type> = Type extends Exclude<Builtin, Error>
+type DeepReadonlyOptions = {
+  builtin: {
+    date: boolean;
+    error: boolean;
+    regexp: boolean;
+  };
+};
+
+type ConditionalBuiltin<Options extends Required<DeepReadonlyOptions>> =
+  | Primitive
+  | Function
+  | (Options["builtin"]["error"] extends false ? Error : never)
+  | (Options["builtin"]["date"] extends false ? Date : never)
+  | (Options["builtin"]["regexp"] extends false ? RegExp : never);
+
+type DeepReadonlyObjectWithOptions<Type, Options extends Required<DeepReadonlyOptions>> = {
+  readonly [Key in keyof Type]: Key extends typeof Symbol.iterator
+    ? Type[Key] extends () => Iterator<infer IteratorType, infer Return, infer Next>
+      ? () => Iterator<
+          DeepReadonlyWithOptions<IteratorType, Options>,
+          DeepReadonlyWithOptions<Return, Options>,
+          DeepReadonlyWithOptions<Next, Options>
+        >
+      : DeepReadonlyWithOptions<Type[Key], Options>
+    : DeepReadonlyWithOptions<Type[Key], Options>;
+};
+
+type DeepReadonlyWithOptions<
+  Type,
+  Options extends Required<DeepReadonlyOptions>,
+> = Type extends ConditionalBuiltin<Options>
   ? Type
   : Type extends Map<infer Keys, infer Values>
-  ? ReadonlyMap<DeepReadonly<Keys>, DeepReadonly<Values>>
+  ? ReadonlyMap<DeepReadonlyWithOptions<Keys, Options>, DeepReadonlyWithOptions<Values, Options>>
   : Type extends ReadonlyMap<infer Keys, infer Values>
-  ? ReadonlyMap<DeepReadonly<Keys>, DeepReadonly<Values>>
+  ? ReadonlyMap<DeepReadonlyWithOptions<Keys, Options>, DeepReadonlyWithOptions<Values, Options>>
   : Type extends WeakMap<infer Keys, infer Values>
-  ? WeakMap<DeepReadonly<Keys>, DeepReadonly<Values>>
+  ? WeakMap<DeepReadonlyWithOptions<Keys, Options>, DeepReadonlyWithOptions<Values, Options>>
   : Type extends Set<infer Values>
-  ? ReadonlySet<DeepReadonly<Values>>
+  ? ReadonlySet<DeepReadonlyWithOptions<Values, Options>>
   : Type extends ReadonlySet<infer Values>
-  ? ReadonlySet<DeepReadonly<Values>>
+  ? ReadonlySet<DeepReadonlyWithOptions<Values, Options>>
   : Type extends WeakSet<infer Values>
-  ? WeakSet<DeepReadonly<Values>>
+  ? WeakSet<DeepReadonlyWithOptions<Values, Options>>
   : Type extends Promise<infer Value>
-  ? Promise<DeepReadonly<Value>>
+  ? Promise<DeepReadonlyWithOptions<Value, Options>>
   : Type extends AnyArray<infer Values>
   ? IsNever<IsTuple<Type>> extends false
-    ? DeepReadonlyObject<Type>
-    : ReadonlyArray<DeepReadonly<Values>>
+    ? DeepReadonlyObjectWithOptions<Type, Options>
+    : ReadonlyArray<DeepReadonlyWithOptions<Values, Options>>
   : Type extends {}
-  ? DeepReadonlyObject<Type>
+  ? DeepReadonlyObjectWithOptions<Type, Options>
   : IsUnknown<Type> extends true
   ? unknown
   : Readonly<Type>;
+
+export type DeepReadonly<
+  Type,
+  OverrideDeepReadonlyOptions extends { builtin?: Partial<DeepReadonlyOptions["builtin"]> } = {},
+> = DeepReadonlyWithOptions<
+  Type,
+  {
+    builtin: CreateTypeOptions<
+      DeepReadonlyOptions["builtin"],
+      OverrideDeepReadonlyOptions["builtin"] extends {} ? OverrideDeepReadonlyOptions["builtin"] : {},
+      DefaultDeepReadonlyOptions["builtin"]
+    >;
+  }
+>;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: related to #387
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken
- [x] Fixes missing details from https://github.com/ts-essentials/ts-essentials/pull/465

## Overview

1. **Added `DeepReadonlyOptions` type** — defines the shape of options:
   ```ts
   type DeepReadonlyOptions = { builtin: { error: boolean; date: boolean; regexp: boolean } }
   ```

2. **Added `DefaultDeepReadonlyOptions`** — sets defaults (`true` = deep readonly applied, `false` = passthrough):
   ```ts
   { builtin: { date: false; error: true; regexp: false } }
   ```

3. **Added `ConditionalBuiltin`** — builds the passthrough union based on resolved options. Each builtin is included in the passthrough union when its option is `false`.

4. **Refactored internals** into `DeepReadonlyWithOptions` / `DeepReadonlyObjectWithOptions` to thread resolved options through recursion.

5. **Public `DeepReadonly<Type, OverrideDeepReadonlyOptions>`**:
   - Added a second optional type parameter for overrides
   - Constraint is `{ builtin?: Partial<DeepReadonlyOptions["builtin"]> }` — allowing **partial nested overrides** (e.g. `{ builtin: { regexp: true } }` without needing all three sub-keys)
   - Two-level `CreateTypeOptions` merge: outer level handles the `builtin` key, inner level merges each of `date`/`error`/`regexp` individually against defaults

6. Documented the new second type parameter with a configuration table showing each option, its default, and the effect of `true` vs `false`.