### PR TITLE
Fix: `DeepPartial<Type>` when `Type` is an array containing rest element

### DIFF
--- a/.changeset/fuzzy-nails-sip.md
+++ b/.changeset/fuzzy-nails-sip.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Fix `DeepPartial<Type>` when `Type` is an array containing rest element, like `[string, ...number[]]`

--- a/lib/deep-partial/index.test.ts
+++ b/lib/deep-partial/index.test.ts
@@ -53,6 +53,10 @@ function testDeepPartial() {
     Assert<IsExact<DeepPartial<readonly never[]>, readonly undefined[]>>,
     Assert<IsExact<DeepPartial<[1, 2, 3]>, [(1 | undefined)?, (2 | undefined)?, (3 | undefined)?]>>,
     Assert<IsExact<DeepPartial<readonly [1, 2, 3]>, readonly [(1 | undefined)?, (2 | undefined)?, (3 | undefined)?]>>,
+    Assert<IsExact<DeepPartial<[string, ...number[]]>, [(string | undefined)?, ...(number | undefined)[]]>>,
+    Assert<
+      IsExact<DeepPartial<readonly [string, ...number[]]>, readonly [(string | undefined)?, ...(number | undefined)[]]>
+    >,
     Assert<IsExact<DeepPartial<number[]>, (number | undefined)[]>>,
     Assert<IsExact<DeepPartial<readonly number[]>, readonly (number | undefined)[]>>,
     Assert<IsExact<DeepPartial<Array<number>>, Array<number | undefined>>>,
@@ -76,5 +80,11 @@ function testDeepPartial() {
     Assert<IsExact<DeepPartial<{ a: 1; b: 2; c: 3 }>, { a?: 1; b?: 2; c?: 3 }>>,
     Assert<IsExact<DeepPartial<{ foo: () => void }>, { foo?: () => void }>>,
     Assert<IsExact<DeepPartial<ComplexNestedRequired>, ComplexNestedPartial>>,
+    Assert<
+      IsExact<
+        DeepPartial<{ foo: [string, ...number[]] }>,
+        { foo?: [(string | undefined)?, ...(number | undefined)[]] | undefined }
+      >
+    >,
   ];
 }

--- a/lib/deep-partial/index.ts
+++ b/lib/deep-partial/index.ts
@@ -16,12 +16,6 @@ export type DeepPartial<Type> = Type extends Exclude<Builtin, Error>
   ? ReadonlySet<DeepPartial<Values>>
   : Type extends WeakSet<infer Values>
   ? WeakSet<DeepPartial<Values>>
-  : Type extends ReadonlyArray<infer Values>
-  ? Type extends IsTuple<Type>
-    ? { [Key in keyof Type]?: DeepPartial<Type[Key]> }
-    : Type extends Array<Values>
-    ? Array<DeepPartial<Values> | undefined>
-    : ReadonlyArray<DeepPartial<Values> | undefined>
   : Type extends Promise<infer Value>
   ? Promise<DeepPartial<Value>>
   : Type extends {}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: related to #468
- [X] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This is the same issue as mentioned in [this comment](https://github.com/ts-essentials/ts-essentials/issues/434#issuecomment-2966878618):
> The issue is indeed with the `Type extends IsTuple<Type>` conditional, here’s a minimal reproducible example for the same:
> 
> import { IsTuple } from 'ts-essentials';
> 
> // no-op mapped type with `IsTuple` conditional
> type Test<T> = T extends IsTuple<T> ? { [P in keyof T]: T[P] } : never;
> 
> type T = Test<[bigint, ...string[]]>; // `...string[]` changes to `...never[]`
> //   ^? type T = [bigint, ...never[]]
> [Playground](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgSQM4BUCuYA2BTOAXzgDMoIQ4ByGVAWj1VTwDsZgBDHVKgbgFgAUEID0IuCwh0IYOCA5gweACZwYATyVwA7sBgALOAAM0WXHiNwAxhBbK9wW1yEat6RjAA86AHxwAvHDocHgAHjCsyqgoGNj43n4A-IhwANoACnDALHAA1njqECRBALoAXEEZJURwFSx4AG54UALCgq4EwYHuqF6pAEbAAObZMAA0cAB0071Q2UOpJSU+vHBixtOTs-OLllb6HCxDjGoQG9P1TVC7ouJwcAB6yR1BAWmDI2wTm5fNiyVAA)
> 
> So, `T` ends up being `[bigint, ...never[]]`, which is incorrect—it should’ve preserved the `...string[]`.

<br>

This PR _simply_ removes the explicit handling for arrays, as they can be handled the same way as objects without any issues. So, the following _homomorphic_ mapped type should be able to handle both arrays and objects:
https://github.com/ts-essentials/ts-essentials/blob/bb7d19fe4754a6809267c2ba355500f0ea386573/lib/deep-partial/index.ts#L28