### PR TITLE
ci: update actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -36,7 +36,7 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- Updates `actions/checkout` from `v1` / unpinned `master` to `v4` across all three workflows
  - `ci.yml`: `v1` → `v4`
  - `release.yml`: `@master` → `v4`
  - `typecheck.yml`: `v1` → `v4`

## Why

`actions/checkout@v1` and `@master` are outdated and unpinned. `v4` is the current stable release and uses Node 20 under the hood (v1 used Node 12, which GitHub Actions has deprecated).

## Test plan

- [x] CI workflow passes on this PR
- [x] Typecheck workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)