### PR TITLE
ci: read node version from .nvmrc in all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     name: Test
     strategy:
       matrix:
-        node: ["24.x"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
@@ -20,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       - name: Cache YARN dependencies
@@ -28,8 +27,8 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.OS }}-${{ matrix.node }}-yarn-cache-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.OS }}-${{ matrix.node }}-yarn-cache-
+          key: ${{ runner.OS }}-${{ hashFiles('.nvmrc') }}-yarn-cache-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ runner.OS }}-${{ hashFiles('.nvmrc') }}-yarn-cache-
 
       - run: yarn --no-progress --non-interactive --frozen-lockfile
       - run: yarn test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ jobs:
     name: Release
     strategy:
       matrix:
-        node: ["24.x"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     permissions:
@@ -26,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       - name: Cache YARN dependencies
@@ -34,8 +33,8 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.OS }}-${{ matrix.node }}-yarn-cache-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.OS }}-${{ matrix.node }}-yarn-cache-
+          key: ${{ runner.OS }}-${{ hashFiles('.nvmrc') }}-yarn-cache-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ runner.OS }}-${{ hashFiles('.nvmrc') }}-yarn-cache-
 
       - name: Install
         run: yarn --no-progress --non-interactive --frozen-lockfile

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,7 +11,6 @@ jobs:
     name: TypeScript ${{ matrix.typescript }}
     strategy:
       matrix:
-        node: ["24.x"]
         os: [ubuntu-latest]
         typescript:
           [
@@ -40,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       - name: Cache YARN dependencies
@@ -48,8 +47,8 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.OS }}-${{ matrix.node }}-yarn-cache-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.OS }}-${{ matrix.node }}-yarn-cache-
+          key: ${{ runner.OS }}-${{ hashFiles('.nvmrc') }}-yarn-cache-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ runner.OS }}-${{ hashFiles('.nvmrc') }}-yarn-cache-
 
       - run: yarn --no-progress --non-interactive --frozen-lockfile
       - run: yarn add typescript@${{ matrix.typescript }}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: related to #000
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

Replaces the hardcoded `node: ["24.x"]` matrix entry in all three workflows with `node-version-file: ".nvmrc"` in `actions/setup-node@v4`. This ensures CI always uses the same Node version as local development without requiring manual updates in multiple places.

Changes across `ci.yml`, `release.yml`, and `typecheck.yml`:
- Removed `node` from the strategy matrix
- Switched `node-version: ${{ matrix.node }}` → `node-version-file: ".nvmrc"`
- Updated cache keys to use `hashFiles('.nvmrc')` instead of `matrix.node`, so the cache is properly invalidated when the Node version changes in `.nvmrc`